### PR TITLE
site movers updates

### DIFF
--- a/Job.py
+++ b/Job.py
@@ -881,4 +881,12 @@ class FileSpec(object):
         if not is_rootfile:
             return False
 
-        return self.prodDBlockToken != 'local' and is_rootfile
+        is_directaccess = self.prodDBlockToken != 'local' and is_rootfile
+
+        allowed_replica_schemas = ['root://', 'dcache://', 'dcap://']
+
+        if self.turl:
+            if True not in set([self.turl.startswith(e) for e in allowed_replica_schemas]):
+                is_directaccess = False
+
+        return is_directaccess

--- a/movers/base.py
+++ b/movers/base.py
@@ -238,7 +238,12 @@ class BaseSiteMover(object):
                 # match Rucio replica by default protocol se (quick stub until Rucio protocols are proper populated)
                 if protocol.get('se') and r.startswith(ddm_se): # manually form pfn based on protocol.se
                     r_filename = r.replace(ddm_se, '', 1).replace(ddm_path, '', 1) # resolve replica filename
-                    replica = protocol.get('se') + protocol.get('path')
+                    # quick hack: if hosted replica ddmendpoint and input protocol ddmendpoint mismatched => consider replica ddmendpoint.path
+                    r_path = protocol.get('path')
+                    if ddmendpoint != protocol.get('ddm'):
+                        self.log("[stage-in] ignore protocol.path=%s since protocol.ddm=%s differs from found replica.ddm=%s ... will use ddm.path=%s to form TURL" % (protocol.get('path'), protocol.get('ddm'), ddmendpoint, ddm_path))
+                        r_path = ddm_path
+                    replica = protocol.get('se') + r_path
                     if replica and r_filename and '/' not in (replica[-1] + r_filename[0]):
                         replica += '/'
                     replica += r_filename

--- a/movers/base.py
+++ b/movers/base.py
@@ -580,13 +580,13 @@ class BaseSiteMover(object):
     @classmethod
     def calc_checksum(self, filename, command='md5sum', setup=None):
         """
-            calculate the md5 checksum for a file
+            calculate file checksum value
             raise an exception if input filename is not exist/readable
         """
 
         cmd = "%s %s" % (command, filename)
         if setup:
-            cmd = "%s; %s" % (setup, cmd)
+            cmd = "%s 1>/dev/null 2>/dev/null; %s" % (setup, cmd)
 
         self.log("Execute command (%s) to calc checksum of file" % cmd)
 

--- a/movers/base.py
+++ b/movers/base.py
@@ -232,7 +232,7 @@ class BaseSiteMover(object):
             if not replicas:
                 continue
             surl = replicas[0] # assume srm protocol is first entry
-            self.log("[stage-in] surl (srm replica) from Rucio: pfn=%s, ddmendpoint=%s, ddm.se=%s, ddm.se_path" % (surl, ddmendpoint, ddm_se, ddm_path))
+            self.log("[stage-in] surl (srm replica) from Rucio: pfn=%s, ddmendpoint=%s, ddm.se=%s, ddm.se_path=%s" % (surl, ddmendpoint, ddm_se, ddm_path))
 
             for r in replicas:
                 # match Rucio replica by default protocol se (quick stub until Rucio protocols are proper populated)

--- a/movers/mover.py
+++ b/movers/mover.py
@@ -170,7 +170,10 @@ class JobMover(object):
                 if ddm not in r['rses']: # skip not interesting rse
                     continue
                 ddm_se = self.ddmconf[ddm].get('se', '')          ## FIX ME LATER: resolve from default protocol (srm?)
-                ddm_path = self.ddmconf[ddm].get('endpoint', '')  ## 
+                ddm_path = self.ddmconf[ddm].get('endpoint', '')  ##
+
+                if ddm_path and not (ddm_path.endswith('/rucio') or ddm_path.endswith('/rucio/')):
+                    ddm_path += '/rucio/'
 
                 fdat.replicas.append((ddm, r['rses'][ddm], ddm_se, ddm_path))
             if fdat.filesize != r['bytes']:

--- a/movers/mover.py
+++ b/movers/mover.py
@@ -120,7 +120,7 @@ class JobMover(object):
     def resolve_replicas(self, files):
         """
             populates fdat.inputddms and fdat.replicas of each entry from `files` list
-            fdat.replicas = [(ddmendpoint, replica, ddm_se)]
+            fdat.replicas = [(ddmendpoint, replica, ddm_se, ddm_path)]
             ddm_se -- integration logic -- is used to manualy form TURL when ignore_rucio_replicas=True
             (quick stab until all protocols are properly populated in Rucio from AGIS)
         """
@@ -170,7 +170,9 @@ class JobMover(object):
                 if ddm not in r['rses']: # skip not interesting rse
                     continue
                 ddm_se = self.ddmconf[ddm].get('se', '')
-                fdat.replicas.append((ddm, r['rses'][ddm], ddm_se))
+                ddm_path = self.ddmconf[ddm].get('path', '')
+
+                fdat.replicas.append((ddm, r['rses'][ddm], ddm_se, ddm_path))
             if fdat.filesize != r['bytes']:
                 self.log("WARNING: filesize value of input file=%s mismatched with info got from Rucio replica:  job.indata.filesize=%s, replica.filesize=%s, fdat=%s" % (fdat.lfn, fdat.filesize, r['bytes'], fdat))
             cc_ad = 'ad:%s' % r['adler32']

--- a/movers/mover.py
+++ b/movers/mover.py
@@ -169,8 +169,8 @@ class JobMover(object):
             for ddm in fdat.inputddms:
                 if ddm not in r['rses']: # skip not interesting rse
                     continue
-                ddm_se = self.ddmconf[ddm].get('se', '')
-                ddm_path = self.ddmconf[ddm].get('path', '')
+                ddm_se = self.ddmconf[ddm].get('se', '')          ## FIX ME LATER: resolve from default protocol (srm?)
+                ddm_path = self.ddmconf[ddm].get('endpoint', '')  ## 
 
                 fdat.replicas.append((ddm, r['rses'][ddm], ddm_se, ddm_path))
             if fdat.filesize != r['bytes']:

--- a/movers/mover.py
+++ b/movers/mover.py
@@ -173,7 +173,9 @@ class JobMover(object):
                 ddm_path = self.ddmconf[ddm].get('endpoint', '')  ##
 
                 if ddm_path and not (ddm_path.endswith('/rucio') or ddm_path.endswith('/rucio/')):
-                    ddm_path += '/rucio/'
+                    if ddm_path[-1] != '/':
+                        ddm_path += '/'
+                    ddm_path += 'rucio/'
 
                 fdat.replicas.append((ddm, r['rses'][ddm], ddm_se, ddm_path))
             if fdat.filesize != r['bytes']:

--- a/movers/mover.py
+++ b/movers/mover.py
@@ -320,10 +320,14 @@ class JobMover(object):
                     is_directaccess = False
                 elif self.job.accessmode == 'direct':
                     is_directaccess = True
+
+                if sitemover.name == 'rucio': ### quick stub: FIX ME later: introduce special DirectAccessMover instance
+                    self.log("Direct access mode will be ignored since Rucio site mover is requested")
+                    is_directaccess = False
+
                 if fdata.is_directaccess() and is_directaccess: # direct access mode, no transfer required
                     fdata.status = 'direct_access'
                     updateFileState(fdata.lfn, self.workDir, self.job.jobId, mode="transfer_mode", state="direct_access", ftype="input")
-
                     self.log("Direct access mode will be used for lfn=%s .. skip transfer the file" % fdata.lfn)
                     continue
 
@@ -331,7 +335,7 @@ class JobMover(object):
                 try:
                     is_stagein_allowed = sitemover.is_stagein_allowed(fdata, self.job)
                     if not is_stagein_allowed:
-                        reason = 'SiteMover does not allowed stage-in operation for the job'
+                        reason = 'SiteMover does not allow stage-in operation for the job'
                 except PilotException, e:
                     is_stagein_allowed = False
                     reason = e


### PR DESCRIPTION
Site movers logic updates and bugfixes:
 -  fixed issue with proper parsing output of check sum calculation command (output suppression of setup command) [lcgcp mover issues]
 - fixed logic of replica url construction for explicitly defined protocols (SE+path) at the level of PandaQueue (PQ.aprotocols settings) [dcap issues]
 - hotfix for default ddm.endpoint path (force to check and fix  '/rucio/' part)
 -  fixed logic to construct input replica url (ignore input protocol.path if found replica belongs to different ddmendpoint)
 - direct access logic updates (allow direct access only for root, dcache or dcap input replicas)