### PR TITLE
Main dev

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -504,6 +504,28 @@ File Changes
 M ATLASSiteInformation.py (2)
 M RunJobEvent.py (14)
 
+
+Updates from Taylor Childers:
+
+-   Added code to write a file named batchid.<batchid>.txt to disk after the batch job is submitted so one does not have to scour the logs to find the id.
+-   Standardizing the many Loggers we have under HPC. They now all use UTC time in the same format and include the process id to help isolate multithreading messages. Al
+    so added the process id to the main pilot Logger.
+-   Removed the sys.exit call which do not allow MPI to finalize properly. If MPI Finize is never called jobs can run on past execution end, wasting wallclock hours
+-   Added more logging messages and changed from using the depricated commands module to the subprocess module for executing slurm commands
+-   Changed Logging to standard logging module and brought the MPI import to the top so that MPI.COMM_WORLD.Abort could be called when errors occur. Abort ensures all 
+    MPI ranks are killed. I added this because I was seeing failures where the worker nodes were not being released even though all processes had exited.
+
+Files changed:
+HPC/HPCJob.py
+HPC/HPCManagerPlugins/slurm.py
+HPC/Logger.py
+HPC/pandayoda/yodacore/Logger.py
+HPC/pandayoda/yodaexe/Droid.py
+Logger.py
+RunJobHpcEvent.py
+pUtil.py
+
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 TODO:

--- a/HPC/HPCManagerPlugins/slurm.py
+++ b/HPC/HPCManagerPlugins/slurm.py
@@ -1,6 +1,6 @@
 
-import commands
-import os
+import subprocess
+import os,time
 
 from HPC.Logger import Logger
 from HPC.HPCManagerPlugins.plugin import Plugin
@@ -15,7 +15,7 @@ class slurm(Plugin):
         #cmd = 'showbf -p %s' % partition
         cmd = 'sinfo '
         self.__log.info("Executing command: '%s'" % cmd)
-        res_tuple = commands.getstatusoutput(cmd)
+        res_tuple = runcommand(cmd)
         self.__log.info("Executing command output: %s" % str(res_tuple))
         showbf_str = ""
         if res_tuple[0] == 0:
@@ -127,7 +127,7 @@ class slurm(Plugin):
         self.__log.info("submit script:\n%s" % submit_script)
         cmd = "sbatch " + self.__submit_file
         self.__log.info("submitting HPC job: %s" % cmd)
-        status, output = commands.getstatusoutput(cmd)
+        status, output = runcommand(cmd)
         self.__log.info("submitting HPC job: (status: %s, output: %s)" %(status, output))
         self.__jobid = None
         if status == 0:
@@ -139,7 +139,7 @@ class slurm(Plugin):
         # poll the job in HPC. update it
         cmd = "scontrol show job " + jobid
         self.__log.info("polling HPC job: %s" % cmd)
-        status, output = commands.getstatusoutput(cmd)
+        status, output = runcommand(cmd)
         # self.__log.info("polling HPC job: (status: %s, output: %s)" %(status, output))
         if status == 0:
             self.__failedPollTimes = 0
@@ -154,15 +154,21 @@ class slurm(Plugin):
                 self.__log.info("HPC job complete")
                 return "Complete"
             if state == "RUNNING":
+                self.__log.info("HPC job is running")
                 return "Running"
             if state == "PENDING":
+                self.__log.info("HPC job is pending")
                 return "Queue"
             if state == "FAILED":
+                self.__log.info("HPC job is failed")
                 return "Failed"
             if state == "CANCELLED":
+                self.__log.info("HPC job is cancelled")
                 return "Failed"
             if state == "TIMEOUT":
+                self.__log.info("HPC job is timed out")
                 return "Failed"
+            self.__log.info("HPC job is in unknown state")
             return 'Unknown'
         else:
             self.__log.info("polling HPC job: (status: %s, output: %s)" %(status, output))
@@ -172,13 +178,23 @@ class slurm(Plugin):
             else:
                 self.__failedPollTimes += 1
                 if self.__failedPollTimes > 5:
+                    self.__log.error('Failing HPC job because the polling command has failed ' + str(self.__failedPollTimes) + ' and is allowed to fail ' + str(5) + ' times.')
                     return "Failed"
                 else:
+                    self.__log.warning('HPC job in unknown state because polling comand returned non-zero value.')
                     return 'Unknown'
         return 'Unknown'
 
     def delete(self, jobid):
         command = "scancel " + jobid
-        status, output = commands.getstatusoutput(command)
+        status, output = runcommand(command)
         self.__log.debug("Run Command: %s " % command)
         self.__log.debug("Status: %s, Output: %s" % (status, output))
+
+
+def runcommand(cmd):
+   p = subprocess.Popen(cmd.split(),stdout=subprocess.PIPE,stderr=subprocess.STDOUT)
+   while p.poll() is None:
+      time.sleep(1)
+   stdout,stderr = p.communicate()
+   return (p.returncode,stdout)

--- a/HPC/Logger.py
+++ b/HPC/Logger.py
@@ -1,6 +1,6 @@
 import logging
 import inspect
-import sys
+import sys,time
 
 loggerMap = {}
 
@@ -19,12 +19,13 @@ class Logger:
             self.log = loggerMap[modName]
         else:
             # make handler
-            fmt = logging.Formatter('%(asctime)s %(name)s: %(levelname)s  %(message)s')
+            fmt = logging.Formatter('%(asctime)s|%(process)s|%(name)s|%(levelname)s| %(message)s',"%Y-%m-%d %H:%M:%S")
             if filename:
                 sh = logging.FileHandler(filename, mode='a')
             else:
                 sh = logging.StreamHandler(sys.stdout)
             sh.setLevel(logging.DEBUG)
+            fmt.converter = time.gmtime
             sh.setFormatter(fmt)
             # make logger
             self.log = logging.getLogger(modName)

--- a/HPC/pandayoda/yodacore/Logger.py
+++ b/HPC/pandayoda/yodacore/Logger.py
@@ -1,5 +1,5 @@
 import logging
-import inspect
+import inspect,time
 
 loggerMap = {}
 
@@ -19,7 +19,7 @@ class Logger:
         else:
             # make handler
             """
-            fmt = logging.Formatter('%(asctime)s %(name)s: %(levelname)s  %(message)s')
+            fmt = logging.Formatter('%(asctime)s|%(process)s|%(name)s|%(levelname)s| %(message)s')
             for handler in logging.root.handlers:
                 handler.setFormatter(fmt)
 
@@ -29,7 +29,8 @@ class Logger:
                 self.log.addHandler(handler)
             """
             self.log = logging.getLogger(modName)
-            fmt = logging.Formatter('%(asctime)s %(name)s: %(levelname)s  %(message)s')
+            fmt = logging.Formatter('%(asctime)s|%(process)s|%(name)s|%(levelname)s| %(message)s',"%Y-%m-%d %H:%M:%S")
+            fmt.converter = time.gmtime
             for handler in logging.root.handlers:
                 handler.setFormatter(fmt)
 

--- a/HPC/pandayoda/yodaexe/Droid.py
+++ b/HPC/pandayoda/yodaexe/Droid.py
@@ -495,7 +495,6 @@ class Droid(threading.Thread):
             os.chdir(self.__globalWorkingDir)
             self.__tmpLog.info("Rank %s: Droid finishes to run one job" % self.__rank)
         self.finishDroid()
-        sys.exit(0)
         return 0
             
     def stop(self, signum=None, frame=None):
@@ -520,7 +519,7 @@ class Droid(threading.Thread):
         self.__tmpLog.info('Rank %s: stop' % self.__rank)
         #signal.siginterrupt(signum, True)
         unblock_sig(signum)
-        sys.exit(0)
+        #sys.exit(0)
 
     def __del_not_use__(self):
         self.__tmpLog.info('Rank %s: __del__ function' % self.__rank)

--- a/Logger.py
+++ b/Logger.py
@@ -13,11 +13,11 @@ class MyFormatter(logging.Formatter):
 
         logging.Formatter.__init__(self, fmt)
 
-        self.info_fmt = '%(asctime)s (UTC) [ %(levelname)s ] %(name)s %(filename)s: %(message)s'
-        self.debug_fmt = '%(asctime)s (UTC) [ %(levelname)s ] %(name)s %(filename)s:%(lineno)d %(funcName)s(): %(message)s'
-        self.warning_fmt = '%(asctime)s (UTC) [ %(levelname)s ] %(name)s %(filename)s:%(lineno)d %(funcName)s(): %(message)s'
-        self.error_fmt = '%(asctime)s (UTC) [ %(levelname)s ] %(name)s %(filename)s:%(lineno)d %(funcName)s(): %(message)s'
-        self.critical_fmt = '%(asctime)s (UTC) [ %(levelname)s ] %(name)s %(filename)s:%(lineno)d %(funcName)s(): %(message)s'
+        self.info_fmt = '%(asctime)s (UTC) %(process)s [ %(levelname)s ] %(name)s %(filename)s: %(message)s'
+        self.debug_fmt = '%(asctime)s (UTC) %(process)s [ %(levelname)s ] %(name)s %(filename)s:%(lineno)d %(funcName)s(): %(message)s'
+        self.warning_fmt = '%(asctime)s (UTC) %(process)s [ %(levelname)s ] %(name)s %(filename)s:%(lineno)d %(funcName)s(): %(message)s'
+        self.error_fmt = '%(asctime)s (UTC) %(process)s [ %(levelname)s ] %(name)s %(filename)s:%(lineno)d %(funcName)s(): %(message)s'
+        self.critical_fmt = '%(asctime)s (UTC) %(process)s [ %(levelname)s ] %(name)s %(filename)s:%(lineno)d %(funcName)s(): %(message)s'
 
     def format(self, record):
 

--- a/RunJobHpcEvent.py
+++ b/RunJobHpcEvent.py
@@ -1053,7 +1053,10 @@ class RunJobHpcEvent(RunJob):
         tolog("Submit HPC job")
         hpcManager.submit()
         tolog("Submitted HPC job")
-
+        # create file with batchid in name for reference
+        with open('batchid.' + str(hpcManager.getHPCJobId()) + '.txt','w') as file:
+            file.write(str(hpcManager.getHPCJobId()))
+            file.close()
         if hpcManager.isLocalProcess():
             self.__hpcStatue = 'closed'
             self.updateAllJobsState('finished', self.__hpcStatue)

--- a/pUtil.py
+++ b/pUtil.py
@@ -161,9 +161,9 @@ def tolog(msg, tofile=True, label='INFO', essential=False):
             module_name = "unknown"
             #print "Exception caught by tolog(): ", e,
         module_name_cut = module_name[0:MAXLENGTH].ljust(MAXLENGTH)
-        msg = "%s| %s" % (module_name_cut, msg)
+        msg = "%i|%s| %s" % (os.getpid(),module_name_cut, msg)
 
-        t = timeStampUTC()
+        t = timeStampUTC(format='%Y-%m-%d %H:%M:%S')
         if tofile:
             appendToLog("%s|%s\n" % (t, msg))
 


### PR DESCRIPTION
Hi Paul,

This is my first pull request, I hope it works correctly :)

My changes for now are mainly to unify the time format used across all the logging to ease the mining of log files for performance data. This includes a change to the pUtils.tolog, review it and feel free to deny my change if you like. I also replace some use of the 'commands' module, which is deprecated, in the HPCManager with 'subprocess' which is the new module for 2.7+. Then I made changes to HPCJob, which is the main driver of the HPC batch job, so that it will kill lingering MPI ranks if something goes wrong instead of wasting wall time in a defunct state.

I've run with these changes at NERSC, but not elsewhere. I'm not sure if that qualifies as tested code.

Oh, almost forgot, I also added the process id to the logging information. This is useful in separating out multiprocess logs.

Let me know if I did something wrong.

Cheers,
Taylor