### PR TITLE
site movers updates

### DIFF
--- a/Job.py
+++ b/Job.py
@@ -475,13 +475,9 @@ class Job:
         pUtil.tolog("Updated ddmEndPointLog=%s" % self.ddmEndPointLog)
 
         self.jobPars = data.get('jobPars', '')
-        putLogToOS = data.get('putLogToOS', 'False')
-        #putLogToOS = 'True'
-        if putLogToOS.lower() == 'true':
-            self.putLogToOS = True
-        else:
-            self.putLogToOS = False
-        pUtil.tolog("putLogToOS = %s" % str(self.putLogToOS))
+
+        self.putLogToOS = str(data.get('putLogToOS')).lower() == 'true'
+        pUtil.tolog("putLogToOS = %s" % self.putLogToOS)
 
         # for accessmode testing: self.jobPars += " --accessmode=direct"
 

--- a/JobLog.py
+++ b/JobLog.py
@@ -94,6 +94,7 @@ class JobLog:
             tolog("Removed directory: %s" % (_dir))
 
 
+    ## new sitemovers based implementation
     def transferLogFile_new(self, job, site,
                             experiment, ## useless => consider job.experiment instead of
                             dest=None,  ## old workflow?: destination dir: if set then apply mv logfile to `dst`, no other real transfers
@@ -135,29 +136,50 @@ class JobLog:
 
             tolog("Special log transfer: Attempting log file transfer to ObjectStore")
 
-            ret, _dummy = self.transferActualLogFile_new(job, site, experiment, jr=jr, specialTransfer=True, copytool="objectstore")
+            job_work_dir = job.workdir
+            try:
+                t0 = os.times()
+                ### fix job.workdir since log files are located outside job dir
+                job.workdir = site.workdir ### quick hack: FIX ME LATER
+                rc, pilotErrorDiag, rf, _dummy, filesNormalStageOut, filesAltStageOut = mover.put_data_new(job, site, stageoutTries=self.__env['stageoutretry'], special_log_transfer=True, workDir=site.workdir)
 
-            if not ret:
-                tolog("WARNING: Failed to transfer log file to special SE (ObjectStore)")
+                #job.filesNormalStageOut += filesNormalStageOut
+                #job.filesAltStageOut += filesAltStageOut
+
+                t1 = os.times()
+                job.timeStageOutLogSpecial = int(round(t1[4] - t0[4]))
+
+            except Exception, e:
+                t1 = os.times()
+                job.timeStageOutLogSpecial = int(round(t1[4] - t0[4]))
+
+                error = "FAILED to stage out log: %s, trace=%s" % (e, traceback.format_exc())
+                tolog(error)
+
+                pilotErrorDiag = "failed to stageout log: %s" % e
+                rc = PilotErrors.ERR_PUTFUNCNOCALL
+
+            job.workdir = job_work_dir ### quick hack: restore workdif
+
+            tolog("Put function [stage-outlog special] returned code: %s" % rc)
+
+            if rc:
+                tolog("WARNING: Failed to transfer log file to special SE (ObjectStore) .. skipped")
             else:
                 # Update the OS transfer dictionary
-                # Get the OS name identifier and bucket endpoint
-                si = getSiteInformation(experiment)
-                os_bucket_id = job.logBucketID ###### resolve bucket id
-                os_ddmendpoint = si.getObjectstoreDDMEndpointFromBucketID(os_bucket_id)
-
-                # Add the transferred file to the OS transfer file
-                addToOSTransferDictionary(job.logFile, self.__env['pilot_initdir'], os_bucket_id, os_ddmendpoint)
+                for fspec in job.logSpecialData:
+                    if fspec.status == 'transferred':
+                        addToOSTransferDictionary(fspec.lfn, self.__env['pilot_initdir'], job.logBucketID, job.logDDMEndpoint)
 
         # stage-out log file to regular SE
         tolog("Attempting log file transfer to primary SE")
+
         job_work_dir = job.workdir
+
         try:
             t0 = os.times()
-
-            ### quick hack: FIX ME LATER
             ### fix job.workdir since log files are located outside job dir
-            job.workdir = site.workdir
+            job.workdir = site.workdir ### quick hack: FIX ME LATER
             rc, pilotErrorDiag, rf, _dummy, filesNormalStageOut, filesAltStageOut = mover.put_data_new(job, site, stageoutTries=self.__env['stageoutretry'], log_transfer=True, workDir=site.workdir)
 
             job.filesNormalStageOut += filesNormalStageOut
@@ -184,7 +206,6 @@ class JobLog:
         tolog("Put function [stage-outlog] returned code: %s" % rc)
 
         if rc:
-
             if pilotErrorDiag: # do not overwrite any existing pilotErrorDiag (from a get operation e.g.)
                 if job.pilotErrorDiag:
                     job.pilotErrorDiag += "|"
@@ -225,181 +246,6 @@ class JobLog:
             tolog("WARNING: Could not remove %s: %s" % (WDTxml, e))
 
         return (not rc, job)
-
-
-    def transferActualLogFile_new(self,
-                                  job,
-                                  site,
-                                  experiment,
-                                  jr=False,
-                                  specialTransfer=False,
-                                  copytool=None):
-        """
-        Save log tarball in DDM and register it to catalog
-        the job recovery will use the current site info known by the current pilot
-        """
-
-
-        if not self.__env['jobrec']: ###
-            self.__env['errorLabel'] = "FAILED"
-
-        # only check for performed log transfer for normal stage-out (not for any special transfers)
-        if isLogfileCopied(site.workdir, job.jobId) and not specialTransfer:
-            tolog("Log file already transferred")
-            return True, job
-
-        # get the log file guid (if not set already)
-        job.tarFileGuid = self.getLogFileGuid(job.tarFileGuid, job.logFile, job.jobId, site.workdir)
-
-        # create the xml needed for the registration if it doesn't exist already (for a secondary log transfer)
-        WDTxml = "%s.xml" % (job.newDirNM)
-        if not os.path.exists(WDTxml):
-            PFCxml(job.experiment, WDTxml, fntag="pfn", alog=job.logFile, alogguid=job.tarFileGuid, jr=jr)
-        else:
-            tolog("Log XML already exists: %s" % (WDTxml))
-
-        dsname = job.logDblock
-        if not dsname or dsname in ['NULL', ' ']:
-            dsname = "%s-%s-%s" % (localtime()[0:3]) # pass it a random name
-
-        # determine the file path for special log transfers (can be overwritten in mover_put_data() in case of failure in transfer to primary OS)
-        logPath, os_bucket_id = "", -1
-        if specialTransfer:
-            logPath, os_bucket_id = self.getLogPath(job.jobId, job.logFile, job.experiment)
-            if not logPath:
-                tolog("!!WARNING!!4444!! Can not continue with special transfer since logPath is not set")
-                return False, job
-
-            tolog("Special log transfer: %s" % logPath)
-
-        status, pilotErrorDiag = True, ""
-        N_filesNormalStageOut, N_filesAltStageOut = 0, 0
-
-        rmflag = 1
-        ec = 0
-
-        try:
-            rc, pilotErrorDiag, _dummy, rs, N_filesNormalStageOut, N_filesAltStageOut, os_bucket_id = mover.mover_put_data("xmlcatalog_file:%s" % (WDTxml),
-                                                                  dsname,
-                                                                  site.sitename,
-                                                                  site.computingElement,
-                                                                  analysisJob = isAnalysisJob(job.trf.split(",")[0]), ## -> job.isAnalysisJob()
-                                                                  testLevel = self.__env['testLevel'],
-                                                                  proxycheck = self.__env['proxycheckFlag'],
-                                                                  pinitdir = self.__env['pilot_initdir'],
-                                                                  datasetDict = None,
-                                                                  outputDir = self.__env['outputDir'],
-                                                                  stageoutTries = self.__env['stageoutretry'],
-                                                                  cmtconfig = getCmtconfig(job.cmtconfig),
-                                                                  recoveryWorkDir = site.workdir,
-                                                                  logPath = logPath,
-                                                                  os_bucket_id = os_bucket_id,
-                                                                  copytool=copytool,
-                                                                  job = job,
-                                                                  log_transfer = True # new sitemovers required integration parameter
-                                                                  )
-        except Exception, e:
-            rmflag = 0 # don't remove the tarball
-            status = False
-            import traceback
-            trace = traceback.format_exc()
-            pilotErrorDiag = "Exception caught when saving the log tarball: %s, %s" % (str(e), trace)
-            tolog("%s: %s" % (self.__env['errorLabel'], pilotErrorDiag))
-
-        else:
-            tolog("mover_put_data finished with EC = %s" % rc)
-
-            # update transfer numbers in case alt stage-out has been used
-            if N_filesAltStageOut > 0:
-                job.filesNormalStageOut += N_filesNormalStageOut # only reported to jobMetrics in case of alt stage-out
-                job.filesAltStageOut += N_filesAltStageOut
-                tolog("Updated stage-out numbers:")
-                tolog("..filesNormalStageOut = %s" % job.filesNormalStageOut)
-                tolog(".....filesAltStageOut = %s" % job.filesAltStageOut)
-
-            if rc: ## error
-                # remove any trailing "\r" or "\n" (there can be two of them)
-                if rs:
-                    rs = rs.rstrip()
-                    tolog("Error string: %s" % rs)
-
-                # ignore failed OS log transfers (this might change if we only store logs in OS:s)
-                if os_bucket_id != -1 and specialTransfer:
-                    tolog("Ignoring failed special log transfer to OS (resetting log bucket id)")
-                    os_bucket_id = -1
-                    rc = 0
-
-                rmflag = 0 # don't remove the tarball
-                job.result[0] = "holding"
-                ec = rc
-
-            else: ## success
-
-                # create a weak lock file for the log transfer (but not for any special transfer, ie the log transfer to the special/secondary log area)
-                if not specialTransfer:
-                    createLockFile(self.__env['jobrec'], site.workdir, lockfile="LOGFILECOPIED_%s" % job.jobId)
-
-                # to which OS bucket id was the file transferred to?
-                if os_bucket_id != -1:
-                    job.logBucketID = os_bucket_id
-                    tolog("Stored log bucket ID: %s" % job.logBucketID)
-
-            # set the error code for the log transfer only if there was no previous error (e.g. from the get-operation)
-            if job.result[2] == 0:
-                job.result[2] = ec
-                job.pilotErrorDiag = pilotErrorDiag
-            else:
-                # there was a previous error
-                if ec:
-                    # is the new log transfer error of the same type as the earlier error?
-                    if ec == job.result[2]:
-                        tolog("!!WARNING!!1105!! Previous error same as new error: %d" % (ec))
-                    else:
-                        tolog("!!WARNING!!1105!! Previous error (%d) will not be overwritten by the new error (%d)" % (job.result[2], ec))
-                    # ignore holding state for log transfer if previous earlier error was a get error
-                    if job.result[0] == "holding" and not PilotErrors.isRecoverableErrorCode(job.result[2]):
-                        tolog("!!WARNING!!1105!! Resetting HOLDING to FAILED since the previous error is not recoverable")
-                        job.result[0] = "failed"
-
-        # old logic: latereg, no used anymore?
-        job.log_latereg = "False" # to be deprecated?
-        job.log_field = None      # to be deprecated
-
-        # tarball is saved to DDM successfully, so remove everything except the log file which might
-        # still be needed (for creating metadata for failed jobs)
-        if rmflag == 1:
-            if os.path.isdir(job.newDirNM):
-                self.removeTree(job.newDirNM)
-            try:
-                os.remove(WDTxml)
-            except Exception, e:
-                tolog("!!WARNING!!1500!! Could not remove %s: %s" % (WDTxml, str(e)))
-                #status = False
-            else:
-                tolog("%s removed" % (WDTxml))
-        elif rmflag == 0: # something bad happened during put, save the tarball on worker node for further debugging
-            if job.result[0] == 'holding':
-                tolog("Will leave log file %s for later recovery" % (job.logFile))
-                status = False
-                if os.path.isdir(job.newDirNM):
-                    self.removeTree(job.newDirNM)
-        elif os.path.isdir(job.workdir) and (not job.logFile or job.logFile == ''):
-            try:
-                rmtree(job.workdir)
-            except Exception, e:
-                tolog("!!WARNING!!1500!! Could not remove %s: %s" % (job.workdir, str(e)))
-
-        if pilotErrorDiag: # do not overwrite any existing pilotErrorDiag (from a get operation e.g.)
-            if job.pilotErrorDiag:
-                job.pilotErrorDiag += "|"
-            else:
-                job.pilotErrorDiag = ""
-            job.pilotErrorDiag += "Log put error: " + pilotErrorDiag
-
-
-        return status, job
-
-
 
     @mover.use_newmover(transferLogFile_new)
     def transferLogFile(self, job, site, experiment, dest=None, jr=False):

--- a/JobLog.py
+++ b/JobLog.py
@@ -164,11 +164,12 @@ class JobLog:
             tolog("Put function [stage-outlog special] returned code: %s" % rc)
 
             if rc:
-                tolog("WARNING: Failed to transfer log file to special SE (ObjectStore) .. skipped")
+                tolog("WARNING: Failed to transfer log file to special SE (ObjectStore) .. skipped, error=%s" % pilotErrorDiag)
             else:
                 # Update the OS transfer dictionary
                 for fspec in job.logSpecialData:
                     if fspec.status == 'transferred':
+                        tolog(" -- INFO: lfn=%s has been successfully transferred to OS: %s, bucket_id=%s" % (fspec.lfn, job.logBucketID, job.logDDMEndpoint))
                         addToOSTransferDictionary(fspec.lfn, self.__env['pilot_initdir'], job.logBucketID, job.logDDMEndpoint)
 
         # stage-out log file to regular SE

--- a/JobLog.py
+++ b/JobLog.py
@@ -141,7 +141,7 @@ class JobLog:
                 t0 = os.times()
                 ### fix job.workdir since log files are located outside job dir
                 job.workdir = site.workdir ### quick hack: FIX ME LATER
-                rc, pilotErrorDiag, rf, _dummy, filesNormalStageOut, filesAltStageOut = mover.put_data_new(job, site, stageoutTries=self.__env['stageoutretry'], special_log_transfer=True, workDir=site.workdir)
+                rc, pilotErrorDiag, rf, _dummy, filesNormalStageOut, filesAltStageOut = mover.put_data_new(job, site, stageoutTries=self.__env['stageoutretry'], log_transfer=False, special_log_transfer=True, workDir=site.workdir)
 
                 #job.filesNormalStageOut += filesNormalStageOut
                 #job.filesAltStageOut += filesAltStageOut

--- a/Mover.py
+++ b/Mover.py
@@ -100,7 +100,7 @@ def getProperDatasetNames(realDatasetsIn, prodDBlocks, inFiles):
 
 
 # new mover implementation
-def put_data_new(job, jobSite, stageoutTries, log_transfer, workDir=None):
+def put_data_new(job, jobSite, stageoutTries, log_transfer, special_log_transfer=False, workDir=None):
     """
         Do jobmover.stageout_outfiles or jobmover.stageout_logfiles respect to the log_transfer flag passed
         :backward compatible return:  (rc, pilotErrorDiag, rf, "", filesNormalStageOut, filesAltStageOut)
@@ -128,6 +128,9 @@ def put_data_new(job, jobSite, stageoutTries, log_transfer, workDir=None):
 
     try:
         do_stageout_func = mover.stageout_logfiles if log_transfer else mover.stageout_outfiles
+        if special_log_transfer:
+            do_stageout_func = mover.stageout_logfiles_os
+
         transferred_files, failed_transfers = do_stageout_func()
     except PilotException, e:
         return e.code, str(e), [], "", 0, 0
@@ -159,6 +162,9 @@ def put_data_new(job, jobSite, stageoutTries, log_transfer, workDir=None):
     #        errors.append(str(err))
 
     files = job.outData if not log_transfer else job.logData
+    if special_log_transfer:
+        files = job.logSpecialData
+    
     not_transferred = [e.lfn for e in files if e.status not in ['transferred']]
     if not_transferred:
         err_msg = 'STAGEOUT FAILED: not all output files have been copied: remain files=%s, errors=%s' % ('\n'.join(not_transferred), ';'.join([str(ee) for ee in failed_transfers]))

--- a/Mover.py
+++ b/Mover.py
@@ -100,7 +100,7 @@ def getProperDatasetNames(realDatasetsIn, prodDBlocks, inFiles):
 
 
 # new mover implementation
-def put_data_new(job, jobSite, stageoutTries, log_transfer, special_log_transfer=False, workDir=None):
+def put_data_new(job, jobSite, stageoutTries, log_transfer=False, special_log_transfer=False, workDir=None):
     """
         Do jobmover.stageout_outfiles or jobmover.stageout_logfiles respect to the log_transfer flag passed
         :backward compatible return:  (rc, pilotErrorDiag, rf, "", filesNormalStageOut, filesAltStageOut)
@@ -164,7 +164,7 @@ def put_data_new(job, jobSite, stageoutTries, log_transfer, special_log_transfer
     files = job.outData if not log_transfer else job.logData
     if special_log_transfer:
         files = job.logSpecialData
-    
+
     not_transferred = [e.lfn for e in files if e.status not in ['transferred']]
     if not_transferred:
         err_msg = 'STAGEOUT FAILED: not all output files have been copied: remain files=%s, errors=%s' % ('\n'.join(not_transferred), ';'.join([str(ee) for ee in failed_transfers]))

--- a/Mover.py
+++ b/Mover.py
@@ -102,7 +102,8 @@ def getProperDatasetNames(realDatasetsIn, prodDBlocks, inFiles):
 # new mover implementation
 def put_data_new(job, jobSite, stageoutTries, log_transfer=False, special_log_transfer=False, workDir=None):
     """
-        Do jobmover.stageout_outfiles or jobmover.stageout_logfiles respect to the log_transfer flag passed
+        Do jobmover.stageout_outfiles or jobmover.stageout_logfiles (if log_transfer=True)
+        or jobmover.stageout_logfiles_os (if special_log_transfer=True)
         :backward compatible return:  (rc, pilotErrorDiag, rf, "", filesNormalStageOut, filesAltStageOut)
     """
 
@@ -120,6 +121,10 @@ def put_data_new(job, jobSite, stageoutTries, log_transfer=False, special_log_tr
     mover = JobMover(job, si, workDir=workDir, stageoutretry=stageoutTries)
 
     eventType = "put_sm"
+    if log_transfer:
+        eventType += '_logs'
+    if special_log_transfer:
+        eventType += '_logs_os'
     if job.isAnalysisJob():
         eventType += "_a"
 

--- a/SiteInformation.py
+++ b/SiteInformation.py
@@ -1967,6 +1967,25 @@ class SiteInformation(object):
         return ret
 
 
+    def resolvePandaOSDDMs(self, pandaqueues):
+        """
+            Resolve OS ddmendpoint associated to requested pandaqueues
+            :return: list of accepted ddmendpoints
+        """
+
+        if isinstance(pandaqueues, (str, unicode)):
+            pandaqueues = [pandaqueues]
+
+        r = self.loadSchedConfData(pandaqueues, cache_time=6000) or {} # quick stub: fix me later: schedconf should be loaded only once in any init function from top level, cache_time is used as a workaround here
+        #self.schedconf = r
+
+        ret = {}
+        for pandaqueue in set(pandaqueues):
+            ret[pandaqueue] = r.get(pandaqueue, {}).get('ddmendpoints', [])
+
+        return ret
+
+
     # Optional
     def shouldExecuteBenchmark(self):
         """ Should the pilot execute a benchmark test before asking server for a job? """

--- a/SiteInformation.py
+++ b/SiteInformation.py
@@ -1960,11 +1960,12 @@ class SiteInformation(object):
             copytools = r.get(pandaqueue, {}).get('copytools', {})
             cptools = []
             acopytools = r.get(pandaqueue, {}).get('acopytools', {}).get(activity, [])
-
-            for cp in acopytools or defval or copytools.iterkeys():
-                if acopytools and cp not in copytools: ## ignore unknown copytools
-                    continue
-                cptools.append((cp, copytools[cp]))
+            if acopytools:
+                cptools = [(cp, copytools[cp]) for cp in acopytools if cp in copytools]
+            elif defval:
+                cptools = defval[:]
+            else:
+                cptools = copytools.items()
 
             ret.setdefault(pandaqueue, cptools)
 

--- a/SiteInformation.py
+++ b/SiteInformation.py
@@ -1939,11 +1939,13 @@ class SiteInformation(object):
         return ret
 
 
-    def resolvePandaCopytools(self, pandaqueues, activity):
+    def resolvePandaCopytools(self, pandaqueues, activity, defval=[]):
         """
             Resolve supported copytools by given pandaqueues
-            Check first settings for requested activity (pr, pw), if not set then return all supported copytools
+            Check first settings for requested activity (pr, pw, pl, pls), then defal values,
+            if not set then return all supported copytools
             Return ordered list of accepted copytools
+            :param defval: default copytools values which will be used if no copytools defined for requested activity
             :return: dict('pandaqueue':[(copytool, {settings}), ('copytool_name', {'setup':''}), ])
         """
 
@@ -1957,8 +1959,10 @@ class SiteInformation(object):
         for pandaqueue in set(pandaqueues):
             copytools = r.get(pandaqueue, {}).get('copytools', {})
             cptools = []
-            for cp in r.get(pandaqueue, {}).get('acopytools', {}).get(activity, []) or copytools.iterkeys():
-                if cp not in copytools:
+            acopytools = r.get(pandaqueue, {}).get('acopytools', {}).get(activity, [])
+
+            for cp in acopytools or defval or copytools.iterkeys():
+                if acopytools and cp not in copytools: ## ignore unknown copytools
                     continue
                 cptools.append((cp, copytools[cp]))
 

--- a/movers/mover.py
+++ b/movers/mover.py
@@ -454,7 +454,7 @@ class JobMover(object):
         for fspec in files:
             pfn = os.path.join(self.job.workdir, fspec.lfn)
             if not os.path.isfile(pfn) or not os.access(pfn, os.R_OK):
-                error = "Erron: input pfn file is not exist: %s" % pfn
+                error = "Error: input pfn file is not exist: %s" % pfn
                 self.log(error)
                 raise PilotException(error, code=PilotErrors.ERR_MISSINGOUTPUTFILE, state="FILE_INFO_FAIL")
             fspec.filesize = os.path.getsize(pfn)

--- a/movers/mover.py
+++ b/movers/mover.py
@@ -459,16 +459,18 @@ class JobMover(object):
 
         self.job.logSpecialData = data
 
-        ret = self.stageout(activity, self.job.logSpecialData)
+        copytools = [{'copysetup': '', 'copytool': 'objectstore'}]
+        ret = self.stageout(activity, self.job.logSpecialData, copytools)
         self.job.logBucketID = self.ddmconf.get(ddmendpoint, {}).get('resource', {}).get('bucket_id', -1)
         self.job.logDDMEndpoint = ddmendpoint
 
         return ret
 
-    def stageout(self, activity, files):
+    def stageout(self, activity, files, copytools=None):
         """
             Copy files to dest SE:
             main control function, it should care about alternative stageout and retry-policy for diffrent ddmendpoints
+        :param copytools: default copytools to be used
         :return: list of entries (is_success, success_transfers, failed_transfers, exception) for each ddmendpoint
         :return: (transferred_files, failed_transfers)
         :raise: PilotException in case of error
@@ -479,7 +481,10 @@ class JobMover(object):
 
         pandaqueue = self.si.getQueueName() # FIX ME LATER
         protocols = self.protocols.setdefault(activity, self.si.resolvePandaProtocols(pandaqueue, activity)[pandaqueue])
-        copytools = self.si.resolvePandaCopytools(pandaqueue, activity)[pandaqueue]
+        if copytools:
+            self.log("Mover.stageout() [new implementation] [%s]: default copytools=%s" % (activity, copytools))
+
+        copytools = self.si.resolvePandaCopytools(pandaqueue, activity, copytools)[pandaqueue]
 
         self.log("Mover.stageout() [new implementation] started for activity=%s, files=%s, protocols=%s, copytools=%s" % (activity, files, protocols, copytools))
 

--- a/movers/objectstore_sitemover.py
+++ b/movers/objectstore_sitemover.py
@@ -10,8 +10,7 @@ from pUtil import tolog
 from PilotErrors import PilotException
 
 from commands import getstatusoutput
-from os.path import dirname
-
+import os
 
 class objectstoreSiteMover(rucioSiteMover):
     """ SiteMover that uses rucio sitemover for both get and put functionality """
@@ -27,3 +26,15 @@ class objectstoreSiteMover(rucioSiteMover):
         Overridden method -- unused
         """
         pass
+
+    def getSURL(self, se, se_path, scope, lfn, job=None):
+        """
+            Get final destination SURL of file to be moved
+            job instance is passing here for possible JOB specific processing ?? FIX ME LATER
+        """
+
+        ### quick fix: this actually should be reported back from Rucio upload in stageOut()
+        ### surl is currently (required?) being reported back to Panda in XML
+
+        surl = se + os.path.join(se_path, lfn)
+        return surl


### PR DESCRIPTION
Major sitemovers updates:

  -  Job log processing has been integrated into newer sitemover architecture both for normal stage-out to primary SE and special log file transfers. (get rid of old wrappers) [JobLog]
  - cleaned and updated logic for normal stage-out of logs to primary SE [JobLog.transferLogFile]
  - implemented special log transfer to ObjectStore DDMEndpoints within new sitemover architecture:
      - new activity='pls' ("pilot log secondary/special") introduced to customize the workflow if need
      - objectstoreSiteMover is hardcoded as default sitemover for special log transfers to OS
      - added GetSURL stub function for objectstoreSiteMover
  - various small fixes

Workflow details:

In current implementation, normal stage-out of logs to primary SE is always executed.
Special transfer of log files is applied as optional action and controlled by 'catchall' queue parameter (log_to_objectstore) or jobSpec options like 'eventService' and 'putLogToOS' (actually old doSpecialLogFileTransfer() function is reused).

Job  ignores (possible) failures of special log transfer to OS and will continue job processing in case of OS transfer issues.


