### PR TITLE
Main dev

### DIFF
--- a/EventRanges.py
+++ b/EventRanges.py
@@ -47,7 +47,7 @@ def downloadEventRanges(jobId, jobsetID, taskID, numRanges=10):
 
     return message
 
-def updateEventRange(event_range_id, eventRangeList, jobId, status='finished', os_bucket_id=-1):
+def updateEventRange(event_range_id, eventRangeList, jobId, status='finished', os_bucket_id=-1, errorCode=None):
     """ Update an list of event ranges on the Event Server """
 
     tolog("Updating an event range..")
@@ -64,6 +64,9 @@ def updateEventRange(event_range_id, eventRangeList, jobId, status='finished', o
         # node['cpu'] =  eventRangeList[1]
         # node['wall'] = eventRangeList[2]
     node['eventStatus'] = status
+
+    if errorCode:
+        node['errorCode'] = errorCode
 
     # open connection
     ret = httpConnect(node, url, path=os.getcwd(), mode="UPDATEEVENTRANGE")

--- a/Job.py
+++ b/Job.py
@@ -61,6 +61,7 @@ class Job:
         self.prodSourceLabel = ""          # job label, e.g. 'user', 'test', 'rc_test', 'ddm', 'software', 'ptest'
         self.nEvents = 0                   # number of processed events (read)
         self.nEventsW = 0                  # number of processed events (written)
+        self.nEventsFailed = 0             # number of failed to stageout events
         self.realDatasetsIn = None         # dataset name(s) for input file(s)
         self.cmtconfig = None              # CMTCONFIG value from the task definition
         self.jobState = None               # Current job state (for definition, see JobRecovery class)
@@ -111,6 +112,9 @@ class Job:
         self.eventRanges = None            # Event ranges dictionary
         self.jobsetID = None               # Event range job set ID
         self.pandaProxySecretKey = None    # pandaproxy secret key
+
+        self.subStatus = None           # subStatus of the job
+        self.subError = None            # subError of the job
 
         # zipped event outputs to a file, for event service
         self.outputZipName = None

--- a/PandaServerClient.py
+++ b/PandaServerClient.py
@@ -313,6 +313,7 @@ class PandaServerClient:
         # for hpc status
         if job.hpcStatus:
             node['jobSubStatus'] = job.hpcStatus
+        tolog("jobSubStatus: %s" % job.subStatus)
         if job.subStatus:
             node['jobSubStatus'] = job.subStatus
 

--- a/PandaServerClient.py
+++ b/PandaServerClient.py
@@ -313,8 +313,8 @@ class PandaServerClient:
         # for hpc status
         if job.hpcStatus:
             node['jobSubStatus'] = job.hpcStatus
-        else:
-            node['jobSubStatus'] = ''
+        if job.subStatus:
+            node['jobSubStatus'] = job.subStatus
 
         if job.coreCount and job.coreCount != 'null' and job.coreCount != 'NULL':
             node['coreCount'] = job.coreCount

--- a/RunJobEvent.py
+++ b/RunJobEvent.py
@@ -1276,13 +1276,10 @@ class RunJobEvent(RunJob):
             ec = self.__error.ERR_PUTFUNCNOCALL
             self.__job.setState(["holding", self.__job.result[1], ec])
         else:
+            if self.__job.pilotErrorDiag = pilotErrorDiag
             if self.__job.pilotErrorDiag != "":
-                self.__job.pilotErrorDiag = self.__job.pilotErrorDiag.replace("Put error:", "Objectstore stageout error:")
-                if self.__job.pilotErrorDiag.startswith("Objectstore stageout error:"):
-                    pre = ""
-                else:
-                    pre = "Objectstore stageout error: "
-                self.__job.pilotErrorDiag = pre + tailPilotErrorDiag(self.__job.pilotErrorDiag, size=256-len("Objectstore stageout error: "))
+                self.__job.pilotErrorDiag = self.__job.pilotErrorDiag.replace("Put error:", "Objectstore stageout to bucket(%s) error:" % os_bucket_id)
+                self.__job.pilotErrorDiag = tailPilotErrorDiag(self.__job.pilotErrorDiag, size=256-len("Objectstore stageout to bucket(%s) error:" % os_bucket_id))
 
             tolog("Put function returned code: %d" % (ec))
             if ec == 0:

--- a/RunJobEvent.py
+++ b/RunJobEvent.py
@@ -1642,7 +1642,6 @@ class RunJobEvent(RunJob):
 
                         # Time to update the server
                         msg = updateEventRange(event_range_id, [], self.__job.jobId, status='fatal')
-                        self.__esFatalCode = self.__error.ERR_ESFATAL
                         if msg != "":
                             tolog("!!WARNING!!2145!! Problem with updating event range: %s" % (msg))
                         else:
@@ -1665,6 +1664,7 @@ class RunJobEvent(RunJob):
                                 error_code = self.__error.ERR_TEFATAL
                             else:
                                 error_code = self.__error.ERR_ESFATAL
+                            self.__esFatalCode = error_code
                             result = ["failed", 0, error_code]
                             tolog("Setting error code: %d" % (error_code))
                             self.setJobResult(result)

--- a/RunJobEvent.py
+++ b/RunJobEvent.py
@@ -1276,7 +1276,7 @@ class RunJobEvent(RunJob):
             ec = self.__error.ERR_PUTFUNCNOCALL
             self.__job.setState(["holding", self.__job.result[1], ec])
         else:
-            if self.__job.pilotErrorDiag = pilotErrorDiag
+            self.__job.pilotErrorDiag = pilotErrorDiag
             if self.__job.pilotErrorDiag != "":
                 self.__job.pilotErrorDiag = self.__job.pilotErrorDiag.replace("Put error:", "Objectstore stageout to bucket(%s) error:" % os_bucket_id)
                 self.__job.pilotErrorDiag = tailPilotErrorDiag(self.__job.pilotErrorDiag, size=256-len("Objectstore stageout to bucket(%s) error:" % os_bucket_id))

--- a/RunJobEvent.py
+++ b/RunJobEvent.py
@@ -3026,7 +3026,7 @@ if __name__ == "__main__":
                 else:
                     tolog("No transfer failures detected, job will be set to finished")
                     job.jobState = "finished"
-        job.subStatus = runJob.getSubStatus
+        job.subStatus = runJob.getSubStatus()
         job.setState([job.jobState, job.result[1], job.result[2]])
         runJob.setJobState(job.jobState)
         rt = RunJobUtilities.updatePilotServer(job, runJob.getPilotServer(), runJob.getPilotPort(), final=True)

--- a/RunJobEvent.py
+++ b/RunJobEvent.py
@@ -2627,6 +2627,7 @@ if __name__ == "__main__":
             if time_to_calculate_cuptime < time.time() - 2 * 60:
                 time_to_calculate_cuptime = time.time()
                 job.cpuConsumptionTime = runJob.getCPUConsumptionTimeFromProc(athenaMPProcess.pid)
+                job.subStatus = runJob.getSubStatus()
                 job.nEvents, job.nEventsW, job.nEventsFailed = runJob.getNEvents()
                 tolog("nevents = %s, neventsW = %s, neventsFailed = %s" % (job.nEvents, job.nEventsW, job.nEventsFailed))
                 # agreed to only report stagedout events to panda
@@ -2694,6 +2695,7 @@ if __name__ == "__main__":
                         if time_to_calculate_cuptime < time.time() - 2 * 60:
                             time_to_calculate_cuptime = time.time()
                             job.cpuConsumptionTime = runJob.getCPUConsumptionTimeFromProc(athenaMPProcess.pid)
+                            job.subStatus = runJob.getSubStatus()
                             job.nEvents, job.nEventsW, job.nEventsFailed = runJob.getNEvents()
                             tolog("nevents = %s, neventsW = %s, neventsFailed = %s" % (job.nEvents, job.nEventsW, job.nEventsFailed))
                             # agreed to only report stagedout events to panda
@@ -2853,6 +2855,7 @@ if __name__ == "__main__":
         if not kill:
             tolog("AthenaMP has finished")
 
+        job.subStatus = runJob.getSubStatus()
         job.nEvents, job.nEventsW, job.nEventsFailed = runJob.getNEvents()
         tolog("nevents = %s, neventsW = %s, neventsFailed = %s" % (job.nEvents, job.nEventsW, job.nEventsFailed))
         # agreed to only report stagedout events to panda
@@ -2916,6 +2919,7 @@ if __name__ == "__main__":
 
         runJob.stageOutZipFiles()
 
+        job.subStatus = runJob.getSubStatus()
         job.nEvents, job.nEventsW, job.nEventsFailed = runJob.getNEvents()
         tolog("nevents = %s, neventsW = %s, neventsFailed = %s" % (job.nEvents, job.nEventsW, job.nEventsFailed))
         # agreed to only report stagedout events to panda
@@ -3033,6 +3037,7 @@ if __name__ == "__main__":
 
     except Exception, errorMsg:
 
+        job.subStatus = runJob.getSubStatus()
         job.nEvents, job.nEventsW, job.nEventsFailed = runJob.getNEvents()
         tolog("nevents = %s, neventsW = %s, neventsFailed = %s" % (job.nEvents, job.nEventsW, job.nEventsFailed))
         # agreed to only report stagedout events to panda

--- a/RunJobUtilities.py
+++ b/RunJobUtilities.py
@@ -105,6 +105,8 @@ def updateJobInfo(job, server, port, logfile=None, final=False, latereg=False):
     if job.coreCount or job.coreCount == 0:
         msgdic['coreCount'] = job.coreCount
 
+    if job.subStatus:
+        msgdic['subStatus'] = job.subStatus
 
     # report FAX usage if at least one successful FAX transfer
     if job.filesWithFAX > 0:

--- a/UpdateHandler.py
+++ b/UpdateHandler.py
@@ -83,6 +83,9 @@ class UpdateHandler(BaseRequestHandler):
                         if (tmp == "failed" or tmp == "holding" or tmp == "finished") and jobinfo.has_key("logfile"):
                             self.__env['jobDic'][k][1].logMsgFiles.append(jobinfo["logfile"])
 
+                        if jobinfo.has_key("subStatus"):
+                            self.__env['jobDic'][k][1].subStatus = pUtil.decode_string(jobinfo["subStatus"])
+
                         if jobinfo.has_key("pilotErrorDiag"):
                             self.__env['jobDic'][k][1].pilotErrorDiag = pUtil.decode_string(jobinfo["pilotErrorDiag"])
 

--- a/UpdateHandler.py
+++ b/UpdateHandler.py
@@ -84,7 +84,8 @@ class UpdateHandler(BaseRequestHandler):
                             self.__env['jobDic'][k][1].logMsgFiles.append(jobinfo["logfile"])
 
                         if jobinfo.has_key("subStatus"):
-                            self.__env['jobDic'][k][1].subStatus = pUtil.decode_string(jobinfo["subStatus"])
+                            pUtil.tolog("subStatus: %s" % jobinfo["subStatus"])
+                            self.__env['jobDic'][k][1].subStatus = jobinfo["subStatus"]
 
                         if jobinfo.has_key("pilotErrorDiag"):
                             self.__env['jobDic'][k][1].pilotErrorDiag = pUtil.decode_string(jobinfo["pilotErrorDiag"])


### PR DESCRIPTION
1) report fatal event status. When AthenaMP failed to process one event with FATAL error messages, will report eventStatus='fatal'
2) update eventType to 'put_es'/'get_es'  in trace report when stagein/stageout events.
3) report errorCode in eventStatus when updating failed event range
4) update pilot to report jobsubstatus
5) fix pilot to report objectstore stageout errors