### PR TITLE
Main dev

### DIFF
--- a/RunJobEvent.py
+++ b/RunJobEvent.py
@@ -1892,6 +1892,7 @@ class RunJobEvent(RunJob):
                         tolog("!!WARNING!!2144!! Extracted error acronym %s and error diagnostics \'%s\' for event range %s" % (error_acronym, error_diagnostics, event_range_id))
 
                         error_code = None
+                        event_status = 'failed'
                         # Was the error fatal? If so, the pilot should abort
                         if "FATAL" in error_acronym:
                             tolog("!!WARNING!!2146!! A FATAL error was encountered, prepare to finish")
@@ -1907,13 +1908,16 @@ class RunJobEvent(RunJob):
                                 error_code = self.__error.ERR_TEWRONGGUID
                             elif error_acronym == "ERR_TE_FATAL":
                                 error_code = self.__error.ERR_TEFATAL
+                                event_status = 'fatal'
                             else:
                                 error_code = self.__error.ERR_ESFATAL
                             self.__esFatalCode = error_code
+                        else:
+                            error_code = self.__error.ERR_UNKNOWN
 
                         # Time to update the server
                         self.__nEventsFailed += 1
-                        msg = updateEventRange(event_range_id, [], self.__job.jobId, status='fatal', errorCode=error_code)
+                        msg = updateEventRange(event_range_id, [], self.__job.jobId, status=event_status, errorCode=error_code)
                         if msg != "":
                             tolog("!!WARNING!!2145!! Problem with updating event range: %s" % (msg))
                         else:

--- a/RunJobEvent.py
+++ b/RunJobEvent.py
@@ -1908,7 +1908,7 @@ class RunJobEvent(RunJob):
                                 error_code = self.__error.ERR_TEWRONGGUID
                             elif error_acronym == "ERR_TE_FATAL":
                                 error_code = self.__error.ERR_TEFATAL
-                                event_status = 'fatal'
+                                event_status = 'failed'  # should be 'fatal', we only use 'failed' currently
                             else:
                                 error_code = self.__error.ERR_ESFATAL
                             self.__esFatalCode = error_code

--- a/pUtil.py
+++ b/pUtil.py
@@ -4371,7 +4371,7 @@ def sig2exc(sig, frm):
                 ec = error.ERR_KILLSIGNAL
 
             env['jobDic'][k][1].result[0] = "failed"
-            env['jobDic'][k][1].subStatus = 'pilot_failed'
+            env['jobDic'][k][1].subStatus = 'pilot_killed'
             env['jobDic'][k][1].currentState = env['jobDic'][k][1].result[0]
             # do not overwrite any previous error
             if env['jobDic'][k][1].result[2] == 0:


### PR DESCRIPTION
1) to use 'pilot_killed' instead of 'pilot_failed' when a signal is catched
2) fix event status when an AthenaMP error message is received. Normal athenaMP errors should not be 'fatal'. And currently we will not report fatal until we validate AthenaMP error reports