### PR TITLE
Main dev

### DIFF
--- a/GFAL2SiteMover.py
+++ b/GFAL2SiteMover.py
@@ -266,7 +266,7 @@ class GFAL2SiteMover(SiteMover.SiteMover):
         outputRet["report"]["clientState"] = None
 
         self.log("StageIn files started.")
-        _cmd_str = '%s gfal-copy --verbose -t %s  -D "SRM PLUGIN:TURL_PROTOCOLS=gsiftp" %s file:%s' % (self._setup, self.timeout, source, destination)
+        _cmd_str = '%s gfal-copy --verbose -t %s  -D "SRM PLUGIN:TURL_PROTOCOLS=gsiftp" %s file://%s' % (self._setup, self.timeout, source, destination)
         self.log('Executing command: %s' % (_cmd_str))
         s = -1
         o = '(not defined)'
@@ -512,10 +512,10 @@ class GFAL2SiteMover(SiteMover.SiteMover):
                     token = "ATLASGROUPDISK"
                 tolog("Space token descriptor reset to: %s" % (token))
 
-            _cmd_str = '%s gfal-copy --verbose %s -D "SRM PLUGIN:TURL_PROTOCOLS=gsiftp" -S %s file:%s %s' % (self._setup, timeout_option, token, source, destination)
+            _cmd_str = '%s gfal-copy --verbose %s -D "SRM PLUGIN:TURL_PROTOCOLS=gsiftp" -S %s file://%s %s' % (self._setup, timeout_option, token, source, destination)
         else:
             # surl is the same as putfile
-            _cmd_str = '%s gfal-copy --verbose %s -D "SRM PLUGIN:TURL_PROTOCOLS=gsiftp" file:%s %s' % (self._setup, timeout_option, source, destination)
+            _cmd_str = '%s gfal-copy --verbose %s -D "SRM PLUGIN:TURL_PROTOCOLS=gsiftp" file://%s %s' % (self._setup, timeout_option, source, destination)
 
         ec = -1
         t0 = os.times()

--- a/GFAL2SiteMover.py
+++ b/GFAL2SiteMover.py
@@ -266,7 +266,7 @@ class GFAL2SiteMover(SiteMover.SiteMover):
         outputRet["report"]["clientState"] = None
 
         self.log("StageIn files started.")
-        _cmd_str = '%s gfal-copy --verbose -t %s  -D "SRM PLUGIN:TURL_PROTOCOLS=gsiftp" %s file://%s' % (self._setup, self.timeout, source, destination)
+        _cmd_str = '%s gfal-copy --verbose -t %s  -D "SRM PLUGIN:TURL_PROTOCOLS=gsiftp" %s file://%s' % (self._setup, self.timeout, source, os.path.abspath(destination))
         self.log('Executing command: %s' % (_cmd_str))
         s = -1
         o = '(not defined)'
@@ -512,10 +512,10 @@ class GFAL2SiteMover(SiteMover.SiteMover):
                     token = "ATLASGROUPDISK"
                 tolog("Space token descriptor reset to: %s" % (token))
 
-            _cmd_str = '%s gfal-copy --verbose %s -D "SRM PLUGIN:TURL_PROTOCOLS=gsiftp" -S %s file://%s %s' % (self._setup, timeout_option, token, source, destination)
+            _cmd_str = '%s gfal-copy --verbose %s -D "SRM PLUGIN:TURL_PROTOCOLS=gsiftp" -S %s file://%s %s' % (self._setup, timeout_option, token, os.path.abspath(source), destination)
         else:
             # surl is the same as putfile
-            _cmd_str = '%s gfal-copy --verbose %s -D "SRM PLUGIN:TURL_PROTOCOLS=gsiftp" file://%s %s' % (self._setup, timeout_option, source, destination)
+            _cmd_str = '%s gfal-copy --verbose %s -D "SRM PLUGIN:TURL_PROTOCOLS=gsiftp" file://%s %s' % (self._setup, timeout_option, os.path.abspath(source), destination)
 
         ec = -1
         t0 = os.times()

--- a/Job.py
+++ b/Job.py
@@ -78,6 +78,7 @@ class Job:
         self.filesizeIn = []               # Input file sizes from the dispatcher
         self.checksumIn = []               # Input file checksums from the dispatcher
         self.debug = ""                    # debug = True will trigger the pilot to send stdout tail on job update
+        self.lastState = ""                # record the last state of the job
         self.currentState = ""             # Basically the same as result[0] but includes states like "stagein", "stageout"
         self.vmPeakMax = 0                 # Maximum value of vmPeak
         self.vmPeakMean = 0                # Average value of vmPeak

--- a/Monitor.py
+++ b/Monitor.py
@@ -583,7 +583,7 @@ class Monitor:
 
         return job
 
-    def __updateJobs(self):
+    def __updateJobs(self, onlyUpdateStateChangedJobs=False):
         """ Make final server update for all ended jobs"""
 
         # get the stdout tails
@@ -592,6 +592,11 @@ class Monitor:
         # loop over all parallel jobs, update server, kill job if necessary
         # (after multitasking was removed from the pilot, there is actually only one job)
         for k in self.__env['jobDic'].keys():
+            pUtil.tolog("onlyUpdateStateChangedJobs: %s, lastState: %s, currentState: %s" % (onlyUpdateStateChangedJobs, self.__env['jobDic'][k][1].lastState, self.__env['jobDic'][k][1].currentState))
+            if onlyUpdateStateChangedJobs and self.__env['jobDic'][k][1].lastState == self.__env['jobDic'][k][1].currentState:
+                continue
+            self.__env['jobDic'][k][1].lastState = self.__env['jobDic'][k][1].currentState
+
             tmp = self.__env['jobDic'][k][1].result[0]
             if tmp != "finished" and tmp != "failed" and tmp != "holding":
 
@@ -747,6 +752,8 @@ class Monitor:
 
             # update the time for checking looping jobs
             self.__env['curtime'] = int(time.time())
+
+        self.__updateJobs(onlyUpdateStateChangedJobs=True)
 
     def __set_outputs(self):
         # all output will be written to the pilot log as well as to stdout [with the pUtil.tolog() function]

--- a/RunJobEvent.py
+++ b/RunJobEvent.py
@@ -2630,6 +2630,13 @@ if __name__ == "__main__":
 
         # Setup starts here ................................................................................
 
+        if not os.environ.has_key('ATHENA_PROC_NUMBER'):
+            tolog("ATHENA_PROC_NUMBER not defined, setting it to 1")
+            runCommandList[0] = 'export ATHENA_PROC_NUMBER=1; %s' % (runCommandList[0])
+            job.coreCount = 1
+        else:
+            job.coreCount = int(os.environ['ATHENA_PROC_NUMBER'])
+
         # Update the job state file
         job.jobState = "setup"
         runJob.setJobState(job.jobState)
@@ -2802,13 +2809,6 @@ if __name__ == "__main__":
             job.result[0] = "failed"
             job.result[2] = error.ERR_ESRECOVERABLE
             runJob.failJob(0, job.result[2], job, pilotErrorDiag=pilotErrorDiag)
-
-        if not os.environ.has_key('ATHENA_PROC_NUMBER'):
-            tolog("ATHENA_PROC_NUMBER not defined, setting it to 1")
-            runCommandList[0] = 'export ATHENA_PROC_NUMBER=1; %s' % (runCommandList[0])
-            job.coreCount = 1
-        else:
-            job.coreCount = int(os.environ['ATHENA_PROC_NUMBER'])
 
         # AthenaMP needs to know where exactly is the PFC
         runCommandList[0] += " '--postExec' 'svcMgr.PoolSvc.ReadCatalog += [\"xmlcatalog_file:%s\"]'" % (runJob.getPoolFileCatalogPath())

--- a/UpdateHandler.py
+++ b/UpdateHandler.py
@@ -41,6 +41,7 @@ class UpdateHandler(BaseRequestHandler):
                         old_pilotecode = self.__env['jobDic'][k][1].result[2]
                         old_pilotErrorDiag = self.__env['jobDic'][k][1].pilotErrorDiag
 
+                        self.__env['jobDic'][k][1].lastState = self.__env['jobDic'][k][1].currentState
                         self.__env['jobDic'][k][1].currentState = jobinfo["status"]
                         if jobinfo["status"] == "stagein":
                             self.__env['stagein'] = True


### PR DESCRIPTION
1) in gfal sitemover, to use 'file:///path' instead of 'file:path'.
2)set corecount before setup, because in preemption jobs, jobs are not preempted before report corecount.
3) send heartbeat to panda when job state is changed.