### PR TITLE
soft stop athenamp

### DIFF
--- a/RunJobEvent.py
+++ b/RunJobEvent.py
@@ -1939,11 +1939,10 @@ class RunJobEvent(RunJob):
                             tolog("Updated server for failed event range")
 
                         if error_code:
-                            result = ["failed", 0, error_code]
-                            tolog("Setting error code: %d" % (error_code))
-                            self.setJobResult(result, pilot_failed=True)
-
-                            # ..
+                            # result = ["failed", 0, error_code]
+                            tolog("Error code: %d, send 'No more events' to stop AthenaMP" % (error_code))
+                            # self.setJobResult(result, pilot_failed=True)
+                            self.sendMessage("No more events")
                     else:
                         tolog("!!WARNING!!2245!! Extracted error acronym %s and error diagnostics \'%s\' (event range could not be extracted - cannot update server)" % (error_acronym, error_diagnostics))
 


### PR DESCRIPTION
old function would cause the monitor process to kill runjobevent process. as a result, the final status would not be set correctly.
new way will stop athenamp softly.  let runjobevent have time to set the final state.