### PR TITLE
HammerCloud parameters

### DIFF
--- a/ATLASExperiment.py
+++ b/ATLASExperiment.py
@@ -367,6 +367,9 @@ class ATLASExperiment(Experiment):
         if 'HPC_HPC' in readpar("catchall"):
             cmd = 'export JOB_RELEASE=%s;export JOB_HOMEPACKAGE=%s;JOB_CACHEVERSION=%s;JOB_CMTCONFIG=%s;%s' % (job.release, job.homePackage, cacheVer, cmtconfig, cmd)
 
+        if os.environ.has_key('ALRB_asetupVersion'):
+            cmd = 'export ALRB_asetupVersion=%s;%s' % (os.environ['ALRB_asetupVersion'], cmd)
+
         tolog("\nCommand to run the job is: \n%s" % (cmd))
 
         return 0, pilotErrorDiag, cmd, special_setup_cmd, JEM, cmtconfig

--- a/ATLASSiteInformation.py
+++ b/ATLASSiteInformation.py
@@ -756,7 +756,10 @@ class ATLASSiteInformation(SiteInformation):
         # cmd = 'export ATLAS_LOCAL_ROOT_BASE=%s/atlas.cern.ch/repo/ATLASLocalRootBase; ' % (self.getFileSystemRootPath())
         # cmd += 'source ${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh --quiet; '
         # cmd += 'source ${ATLAS_LOCAL_ROOT_BASE}/packageSetups/atlasLocalROOTSetup.sh --rootVersion ${rootVersionVal} --skipConfirm; '
-        cmd = 'source %s/atlas.cern.ch/repo/sw/local/xrootdsetup.sh' % (self.getFileSystemRootPath())
+        if hasattr(self, 'xrootd_test') and self.xrootd_test:
+            cmd = 'source %s/atlas.cern.ch/repo/sw/local/xrootdsetup-dev.sh' % (self.getFileSystemRootPath())
+        else:
+            cmd = 'source %s/atlas.cern.ch/repo/sw/local/xrootdsetup.sh' % (self.getFileSystemRootPath())
 
         return cmd
 


### PR DESCRIPTION
Introduced the new way of presenting HammerCloud parameter `--overwriteQueuedata`, added two more parameters: `--useTestASetup` and `--useTestXRootD`.

The proposed way for the new `--overwriteQueuedata` is to use common shell syntax.
The old way is yet supported.
In the new syntax `--overwriteQueuedata` is a multiargument parameter, that receives after it a set of parameters represented in `key=value` form. The set is ended when next parameter starts with `-` or with parameter `--`, that will be stripped.
There is another syntax variant: `--overwriteQueuedata <JSON>`
The value in the parameter may be either a string or a valid JSON.
The escape sequences are posix shell compatible, so JSON should be probably wrapped into single quotes.
The argument string is parsed by shlex.

**Examples** of `--overwriteQueuedata` (assuming TRF is echo, lines do not include TRF):

1) **Stripped end-of-parameters**
The line
`this is --overwriteQueuedata key1 key2=null key3='{"a":1,"b":2}' -- test`
will result in
queuedata modification key1=True, key2=None, key3={a:1,b:2}
and command `echo this is test`

2) **End-of-parameters is a dash-prefix of the next parameter**
The line
`this is --overwriteQueuedata key1 key2=null key3='{"a":1,"b":2}' -test`
will result in
queuedata modification key1=True, key2=None, key3={a:1,b:2}
and command `echo this is -test`

3) **Second occurrence and EOL as an end-of-parameters**
`this is --overwriteQueuedata key1 key2=null key3='{"a":1,"b":2}' -test --overwriteQueuedata key4`
will result in
queuedata modification key1=True, key2=None, key3={a:1,b:2}, key4=True
and command `echo this is -test`

4) **JSON**
The line
`this is --overwriteQueuedata '{"key1":1,"key2":2}' test`
will result in
queuedata modification key1=1, key2=2
and command `echo this is test`