### PR TITLE
do not call dispatcher for ND pilots

### DIFF
--- a/pilot.py
+++ b/pilot.py
@@ -2325,13 +2325,15 @@ def getNewJob(tofile=True):
     newJob.datadir = env['thisSite'].workdir + "/PandaJob_%s_data" % (newJob.jobId)
     newJob.experiment = env['experiment']
 
-    # make sure that there is not already a job with this jobid in a running state (due to batch system bug on ND)
+    # make sure that there is not already a job with this jobid in a running state
+    # (due to batch system bug with aCT true pilots)
     # get job status from server
-    jobStatus, jobAttemptNr, jobStatusCode = pUtil.getJobStatus(newJob.jobId, env['pshttpurl'], env['psport'], env['pilot_initdir'])
-    if jobStatus == "running":
-        pilotErrorDiag = "!!WARNING!!1200!! Job %s is already running elsewhere - aborting" % (newJob.jobId)
-        pUtil.tolog("!!WARNING!!1200!! %s" % (pilotErrorDiag), tofile=tofile)
-        return None, pilotErrorDiag
+    if newJob.experiment != 'Nordugrid-ATLAS':
+        jobStatus, jobAttemptNr, jobStatusCode = pUtil.getJobStatus(newJob.jobId, env['pshttpurl'], env['psport'], env['pilot_initdir'])
+        if jobStatus == "running":
+            pilotErrorDiag = "!!WARNING!!1200!! Job %s is already running elsewhere - aborting" % (newJob.jobId)
+            pUtil.tolog("!!WARNING!!1200!! %s" % (pilotErrorDiag), tofile=tofile)
+            return None, pilotErrorDiag
 
     if data.has_key('logGUID'):
         logGUID = data['logGUID']


### PR DESCRIPTION
The call to the dispatcher to check the job status should only be for the "true pilot" jobs, that is the jobs where aCT fetches the job and pushes to the CE, but then the normal pilot workflow runs with staging, heartbeats etc. For the "NorduGrid" jobs where there is no proxy or network connection we shouldn't do the check of the status since the problem of rerunning the job doesn't happen. Sorry for not being clearer on this when we requested this feature.