### PR TITLE
Main dev

### DIFF
--- a/Job.py
+++ b/Job.py
@@ -140,6 +140,9 @@ class Job:
         self.mode = None
         self.hpcStatus = None
 
+        # allow to read/download inputs remotely
+        self.allowRemoteInputs = False
+
         # yoda accounting info
         self.yodaJobMetrics = None
 
@@ -220,6 +223,12 @@ class Job:
 
     def getHpcStatus(self):
         return self.hpcStatus
+
+    def setAllowRemoteInputs(self, allowRemoteInputs):
+        self.allowRemoteInputs = allowRemoteInputs
+
+    def getAllowRemoteInputs(self):
+        return self.allowRemoteInputs
 
     def setJobDef(self, data):
         """ set values for a job object from a dictionary data
@@ -557,6 +566,7 @@ class Job:
                 idat[attrname] = ksources[k][ind] if len(ksources[k]) > ind else None
             if 'lfn' in idat and idat['lfn'].startswith("zip://"):
                 idat['lfn'] = idat['lfn'].replace("zip://", "")
+            idat['allowRemoteInputs'] = self.allowRemoteInputs
             finfo = FileSpec(type='input', **idat)
             self.inData.append(finfo)
 
@@ -844,6 +854,7 @@ class FileSpec(object):
                     'dispatchDblock', 'dispatchDBlockToken',
                     'guid', 'filesize', 'checksum',
                     'prodDBlock', 'prodDBlockToken',
+                    'allowRemoteInputs'
                     ]
 
 

--- a/Mover.py
+++ b/Mover.py
@@ -217,7 +217,7 @@ def put_data_es(job, jobSite, stageoutTries, files, workDir=None):
             copytools = [('objectstore', {'setup': ''})]
         else:
             copytools = None
-        transferred_files, failed_transfers = mover.stageout(activity="pes", files=files, copytools=copytools)
+        transferred_files, failed_transfers = mover.stageout(activity="es_events", files=files, copytools=copytools)
     except PilotException, e:
         error = e
     except Exception, e:

--- a/RunJobEvent.py
+++ b/RunJobEvent.py
@@ -1202,6 +1202,7 @@ class RunJobEvent(RunJob):
                     if 'zip_time_gap' in catchall:
                         name, value = catchall.split('=')
                         self.__asyncOutputStager_thread_sleep_time = int(value)
+            tolog("Sleep time between staging out: %s" % self.__asyncOutputStager_thread_sleep_time)
         except:
             tolog("Failed to init zip cofnig: %s" % traceback.format_exc())
 

--- a/RunJobEvent.py
+++ b/RunJobEvent.py
@@ -1549,7 +1549,7 @@ class RunJobEvent(RunJob):
 
             tolog("[stage-out-os] [%s] resolved os_ddms=%s => es=%s" % (activity, os_ddms, osddms))
 
-            if False: #if osddms:
+            if osddms:
                 self.__stageOutDDMEndpoint = osddms[0]
                 self.__stageOutObjectstoreId = ddmconf.get(self.__stageOutDDMEndpoint, {}).get('resource', {}).get('bucket_id', -1)
             else:

--- a/RunJobEvent.py
+++ b/RunJobEvent.py
@@ -1557,11 +1557,13 @@ class RunJobEvent(RunJob):
                 associate_storages = self.__siteInfo.resolvePandaAssociatedStorages(pandaqueue).get(pandaqueue, {})
                 esDDMEndpoints = associate_storages.get(activity, [])
                 if esDDMEndpoints:
+                    tolog("[stage-out-os] found associated storages %s with activity: %s" % (esDDMEndpoints, activity))
                     self.__stageOutDDMEndpoint = esDDMEndpoints[0]
                     self.__stageOutObjectstoreId = ddmconf.get(self.__stageOutDDMEndpoint, {}).get('resource', {}).get('bucket_id', -1)
                 else:
                     return PilotErrors.ERR_NOSTORAGE, "Failed to stage-out es to OS: no OS_ES ddmendpoint attached to the queue(os_ddms:%s) nor associate es_events activity storage" % (os_ddms), None
 
+            tolog("[stage-out-os] ddmendpoints %s,  objectstoreId %s with activity %s" % (self.__stageOutDDMEndpoint, self.__stageOutObjectstoreId, activity))
             protocols = ddmconf.get(self.__stageOutDDMEndpoint, {}).get('rprotocols', {})
             access_key = None
             secret_key = None

--- a/RunJobHpcEvent.py
+++ b/RunJobHpcEvent.py
@@ -84,6 +84,7 @@ class RunJobHpcEvent(RunJob):
         self.__yoda_to_os = False
         self.__yoda_to_zip = False
         self.__es_to_zip = False
+        self.__stageout_status = False
 
         # for recovery
         self.__jobStateFile = None
@@ -1447,6 +1448,7 @@ class RunJobHpcEvent(RunJob):
             tolog("RunHPCEvent failed: %s" % traceback.format_exc())
 
         self.stageOutZipFiles()
+        self.__stageout_status = True
 
         try:
             hpcManager.postRun()
@@ -1695,7 +1697,8 @@ class RunJobHpcEvent(RunJob):
             tolog("RunHPCEvent failed: %s" % traceback.format_exc())
 
         try:
-            self.stageOutZipFiles()
+            if not self.__stageout_status == True:
+                self.stageOutZipFiles()
         except:
             tolog("RunHPCEvent failed: %s" % traceback.format_exc())
 

--- a/movers/mover.py
+++ b/movers/mover.py
@@ -155,6 +155,8 @@ class JobMover(object):
                 #fdat.inputddms = [fdat.ddmendpoint]         ### is it used for OS?
                 pass
             else:
+                if fdat.objectstoreId == 0:
+                    fdat.objectstoreId = None
                 # build and order list of local ddms
                 ddmdat = self.ddmconf.get(fdat.ddmendpoint)
                 if not ddmdat:

--- a/movers/mover.py
+++ b/movers/mover.py
@@ -183,8 +183,6 @@ class JobMover(object):
             replicas = c.list_replicas(dids, schemes=schemes)
             result = []
             for rep in replicas:
-                if 'SFU-LCG2_DATADISK' in rep['rses']:
-                    del rep['rses']['SFU-LCG2_DATADISK']
                 result.append(rep)
             replicas = result
             self.log("replicas got from rucio: %s" % replicas)
@@ -196,7 +194,6 @@ class JobMover(object):
         for r in replicas:
             k = r['scope'], r['name']
             fdat = files_lfn.get(k)
-            self.log("fdat %s" % fdat)
             if not fdat: # not requested replica returned?
                 continue
             fdat.replicas = [] # reset replicas list
@@ -213,9 +210,6 @@ class JobMover(object):
 
                 fdat.replicas.append((ddm, r['rses'][ddm], ddm_se, ddm_path))
 
-            self.log("fdat.replicas: %s" % fdat.replicas)
-            self.log("fdat.allowRemoteInputs: %s" % fdat.allowRemoteInputs)
-            self.log(not fdat.replicas and fdat.allowRemoteInputs)
             if not fdat.replicas and fdat.allowRemoteInputs:
                 self.log("No local replicas(%s) and allowRemoteInputs is set, looking for remote inputs" % fdat.replicas)
                 for ddm in r['rses']:
@@ -238,7 +232,6 @@ class JobMover(object):
             # update filesize & checksum info from Rucio?
             # TODO
 
-        self.log(files)
         return files
 
     def is_directaccess(self):

--- a/movers/objectstore_sitemover.py
+++ b/movers/objectstore_sitemover.py
@@ -46,15 +46,19 @@ class objectstoreSiteMover(rucioSiteMover):
         Overridden method -- unused
         """
         if ddm:
-            if ddm.get('type') not in ['OS_LOGS', 'OS_ES']:
-                return {}
-            if ddm.get('aprotocols'):
-                surl_schema = 's3'
-                xprot = [e for e in ddm.get('aprotocols').get('r', []) if e[0] and e[0].startswith(surl_schema)]
-                if xprot:
-                    surl = self.getSURL(xprot[0][0], xprot[0][2], fspec.scope, fspec.lfn)
+            if ddm.get('type') in ['OS_LOGS', 'OS_ES']:
+                if ddm.get('aprotocols'):
+                    surl_schema = 's3'
+                    xprot = [e for e in ddm.get('aprotocols').get('r', []) if e[0] and e[0].startswith(surl_schema)]
+                    if xprot:
+                        surl = self.getSURL(xprot[0][0], xprot[0][2], fspec.scope, fspec.lfn)
 
-                    return {'ddmendpoint': fspec.ddmendpoint,
-                            'surl': surl,
-                            'pfn': surl}
+                        return {'ddmendpoint': fspec.ddmendpoint,
+                                'surl': surl,
+                                'pfn': surl}
+            else:
+                if ddm.get('is_deterministic'):
+                   return super(objectstoreSiteMover, self).resolve_replica(fspec, protocol, ddm)
+                else:
+                   return {}
         return {}


### PR DESCRIPTION
1) add allowRemtoeInputs. If it's set, pilot will check local replicas at first. If there is no local replica, pilot will  read/download remote replicas.
2) enable to use activity for es outputs.
    pilot was designed to use special functions to call objectstores in es jobs. new updates make pilot be able to use activity in agis to use storages more than objectstores and different copytools.
3) fix mover part to be able to merge es files from normal storages.
4) fix objectstore sitemover to be able to generate surl for files which are in normal grid storages but not registered in rucio.