### PR TITLE
Main dev

### DIFF
--- a/Job.py
+++ b/Job.py
@@ -1017,7 +1017,7 @@ class FileSpec(object):
                     'cmtconfig' # Needed for Singularity
                     ]
 
-    _os_keys = ['eventRangeId', 'storageId', 'eventService']
+    _os_keys = ['eventRangeId', 'storageId', 'eventService', 'allowAllInputRSEs']
 
     _local_keys = ['type', 'status', 'replicas', 'surl', 'turl', 'mtime', 'status_code']
 
@@ -1030,6 +1030,7 @@ class FileSpec(object):
         self.filesize = int(getattr(self, 'filesize', 0) or 0)
         if self.eventService is None:
             self.eventService = False
+        self.allowAllInputRSEs = False
         self.replicas = []
 
     def __repr__(self):

--- a/Job.py
+++ b/Job.py
@@ -894,6 +894,8 @@ class Job:
         retFiles = {}
         if files is None:
             files = self.inData
+        pUtil.tolog("Staged in files: %s" % files)
+
         for f in files:
             if f.status in ['remote_io']:
                 retFiles["%s:%s" % (f.scope, f.lfn)] = f.turl
@@ -915,7 +917,7 @@ class Job:
                      'dispatchDblock': self.dispatchDblock, 'dispatchDBlockToken': self.dispatchDBlockToken,
                      'dataset': self.realDatasetsIn, 'ddmendpoint': self.ddmEndPointIn,
                      'allowRemoteInputs': allowRemoteInputs}
-            finfo = FileSpec(type='input', **idat)
+            finfo = FileSpec(type='input', **idata)
             reqs.append(finfo)
         return reqs
 
@@ -1014,7 +1016,7 @@ class FileSpec(object):
                     'cmtconfig' # Needed for Singularity
                     ]
 
-    _os_keys = ['eventRangeId', 'objectstoreId']
+    _os_keys = ['eventRangeId', 'storageId']
 
     _local_keys = ['type', 'status', 'replicas', 'surl', 'turl', 'mtime', 'status_code']
 

--- a/Job.py
+++ b/Job.py
@@ -584,6 +584,7 @@ class Job:
                 idat['lfn'] = idat['lfn'].replace("zip://", "")
             idat['allowRemoteInputs'] = self.allowRemoteInputs
             idat['cmtconfig'] = self.cmtconfig
+            idat['eventService'] = self.eventService
             finfo = FileSpec(type='input', **idat)
             self.inData.append(finfo)
 
@@ -1016,7 +1017,7 @@ class FileSpec(object):
                     'cmtconfig' # Needed for Singularity
                     ]
 
-    _os_keys = ['eventRangeId', 'storageId']
+    _os_keys = ['eventRangeId', 'storageId', 'eventService']
 
     _local_keys = ['type', 'status', 'replicas', 'surl', 'turl', 'mtime', 'status_code']
 
@@ -1027,6 +1028,7 @@ class FileSpec(object):
             setattr(self, k, kwargs.get(k, getattr(self, k, None)))
 
         self.filesize = int(getattr(self, 'filesize', 0) or 0)
+        self.eventService = False if self.eventService is None
         self.replicas = []
 
     def __repr__(self):

--- a/Job.py
+++ b/Job.py
@@ -895,7 +895,6 @@ class Job:
         retFiles = {}
         if files is None:
             files = self.inData
-        pUtil.tolog("Staged in files: %s" % files)
 
         for f in files:
             if f.status in ['remote_io']:

--- a/Job.py
+++ b/Job.py
@@ -1028,7 +1028,8 @@ class FileSpec(object):
             setattr(self, k, kwargs.get(k, getattr(self, k, None)))
 
         self.filesize = int(getattr(self, 'filesize', 0) or 0)
-        self.eventService = False if self.eventService is None
+        if self.eventService is None:
+            self.eventService = False
         self.replicas = []
 
     def __repr__(self):

--- a/Mover.py
+++ b/Mover.py
@@ -257,6 +257,7 @@ def get_data_new(job,
                  proxycheck=True,  # TODO
                  inputDir="",      # for mv mover?? not used??
                  workDir="",       # pilot work dir used to check/update file states
+                 files=None,       # input files to stagein
                  pfc_name="PoolFileCatalog.xml"
                  ):
 
@@ -286,7 +287,7 @@ def get_data_new(job,
     mover.trace_report.init(job)
     error = None
     try:
-        output = mover.stagein()
+        output = mover.stagein(files)
     except PilotException, e:
         error = e
         tolog("!!WARNING!!4545!! Caught exception: %s" % (e))

--- a/Mover.py
+++ b/Mover.py
@@ -209,11 +209,11 @@ def put_data_es(job, jobSite, stageoutTries, files, workDir=None):
     mover.trace_report = TraceReport(pq=jobSite.sitename, localSite=jobSite.sitename, remoteSite=jobSite.sitename, dataset="", eventType=eventType)
     mover.trace_report.init(job)
     error = None
-    objectstoreId = None
+    storageId = None
     try:
         file = files[0]
-        if file.objectstoreId and file.objectstoreId != -1:
-            objectstoreId = file.objectstoreId
+        if file.storageId and file.storageId != -1:
+            storageId = file.storageId
             copytools = [('objectstore', {'setup': ''})]
         else:
             copytools = None
@@ -242,7 +242,7 @@ def put_data_es(job, jobSite, stageoutTries, files, workDir=None):
         error = PilotException('STAGEOUT FAILED, exception=%s' % message, code=PilotErrors.ERR_STAGEOUTFAILED, state='STAGEOUT_FAILED')
         return error.code, error.message, None
 
-    return 0, "", objectstoreId
+    return 0, "", storageId
 
 
 # new mover implementation:

--- a/RunJob.py
+++ b/RunJob.py
@@ -618,6 +618,7 @@ class RunJob(object):
                     job,
                     jobSite,
                     analysisJob=None,  # not used: job.isAnalysisJob() should be used instead
+                    files=None,
                     pfc_name="PoolFileCatalog.xml"):
         """
             Perform the stage-in
@@ -639,7 +640,7 @@ class RunJob(object):
 
         t0 = os.times()
 
-        job.result[2], job.pilotErrorDiag, _dummy, FAX_dictionary = mover.get_data_new(job, jobSite, stageinTries=self.__stageinretry, proxycheck=False, workDir=self.__pworkdir, pfc_name=pfc_name)
+        job.result[2], job.pilotErrorDiag, _dummy, FAX_dictionary = mover.get_data_new(job, jobSite, stageinTries=self.__stageinretry, proxycheck=False, workDir=self.__pworkdir, pfc_name=pfc_name, files=files)
 
         t1 = os.times()
 

--- a/RunJobEvent.py
+++ b/RunJobEvent.py
@@ -3437,7 +3437,7 @@ if __name__ == "__main__":
 
         # download event ranges before athenaMP
         # Pilot will download some event ranges from the Event Server
-        message = downloadEventRanges(job.jobId, job.jobsetID, job.taskID, numRanges=job.coreCount, url=runJob.getPanDAServer())
+        message = downloadEventRanges(job.jobId, job.jobsetID, job.taskID, numRanges=job.coreCount * 2, url=runJob.getPanDAServer())
         # Create a list of event ranges from the downloaded message
         first_event_ranges = runJob.extractEventRanges(message)
         if first_event_ranges is None or first_event_ranges == []:
@@ -3485,7 +3485,7 @@ if __name__ == "__main__":
                     first_event_ranges = None
                 else:
                     # Pilot will download some event ranges from the Event Server
-                    message = downloadEventRanges(job.jobId, job.jobsetID, job.taskID, numRanges=job.coreCount, url=runJob.getPanDAServer())
+                    message = downloadEventRanges(job.jobId, job.jobsetID, job.taskID, numRanges=job.coreCount * 2, url=runJob.getPanDAServer())
 
                     # Create a list of event ranges from the downloaded message
                     event_ranges = runJob.extractEventRanges(message)

--- a/RunJobEvent.py
+++ b/RunJobEvent.py
@@ -156,7 +156,7 @@ class RunJobEvent(RunJob):
             return 'all_success'
 
     def setFinalESStatus(self, job):
-        if self.__nStageOutFailures > 5:
+        if self.__nStageOutFailures >= 3:
             job.subStatus = 'pilot_failed'  # 'no_events'
             job.pilotErrorDiag = "Too many stageout failures"
             job.result[0] = "failed"
@@ -3048,10 +3048,11 @@ class RunJobEvent(RunJob):
 
     def checkStageOutFailures(self):
         # if there are two many stageout failures, stop
-        tolog("Continous stageout failures: %s" % self.__nStageOutFailures)
+        if self.__nStageOutFailures > 0:
+            tolog("Continous stageout failures: %s" % self.__nStageOutFailures)
         if self.__nStageOutFailures >= 3:
-             tolog("Too many stageout failures, send 'No more events' to AthenaMP")
-             self.sendMessage("No more events")
+            tolog("Too many stageout failures, send 'No more events' to AthenaMP")
+            self.sendMessage("No more events")
 
 
 # main process starts here

--- a/RunJobEvent.py
+++ b/RunJobEvent.py
@@ -821,7 +821,7 @@ class RunJobEvent(RunJob):
             # Verify that the release version is new enough, otherwise switch off Prefetcher since it is not included in the [old] release
             if release != "":
                 # Can only use Prefetcher for releases >= 21.0.21 or for non-numerical releases (e.g. 'master')
-                _relelase = release.replace('.','')
+                _release = release.replace('.','')
                 if isAGreaterOrEqualToB(release, "21.0.21") or not _release.isdigit():
                     tolog("Prefetcher will be used for release %s" % (release))
                     self.__usePrefetcher = True
@@ -3048,7 +3048,9 @@ class RunJobEvent(RunJob):
 
     def checkStageOutFailures(self):
         # if there are two many stageout failures, stop
-        if self.__nStageOutFailures > 5:
+        tolog("Continous stageout failures: %s" % self.__nStageOutFailures)
+        if self.__nStageOutFailures >= 3:
+             tolog("Too many stageout failures, send 'No more events' to AthenaMP")
              self.sendMessage("No more events")
 
 

--- a/RunJobHpcEvent.py
+++ b/RunJobHpcEvent.py
@@ -1325,6 +1325,13 @@ class RunJobHpcEvent(RunJob):
                 eventstatusFile = str(job.jobId) + "_event_status.dump.zipped"
                 tolog("Copying dump file %s to %s" % (eventstatusFile, os.path.join(outputDir, os.path.basename(eventstatusFile))))
                 shutil.copyfile(eventstatusFile, os.path.join(outputDir, os.path.basename(eventstatusFile)))
+
+                jobMetricsFileName = "jobMetrics-yoda.json"
+                jobMetricsFile = os.path.join(self.__pilotWorkingDir, jobMetricsFileName)
+                if os.path.exists(jobMetricsFile):
+                    tolog("Copying job metrics file %s to %s" % (jobMetricsFile, os.path.join(outputDir, os.path.basename(jobMetricsFile))))
+                    shutil.copyfile(jobMetricsFile, os.path.join(outputDir, os.path.basename(jobMetricsFile)))
+
                 return
 
             report = getInitialTracingReport(userid=job.prodUserID, sitename=self.__jobSite.sitename, dsname=dsname, eventType="objectstore", analysisJob=False, jobId=job.jobId, jobDefId=job.jobDefinitionID, dn=job.prodUserID)

--- a/RunJobHpcEvent.py
+++ b/RunJobHpcEvent.py
@@ -556,8 +556,65 @@ class RunJobHpcEvent(RunJob):
                 break
         self.__hpcStatue = ''
         #self.updateAllJobsState('starting', self.__hpcStatue)
-            
 
+    def stageInOneJob_new(self, job, jobSite, analysisJob, avail_files={}, pfc_name="PoolFileCatalog.xml"):
+        """ Perform the stage-in """
+
+        current_dir = self.__pilotWorkingDir
+        os.chdir(job.workdir)
+        tolog("Start to stage in input files for job %s" % job.jobId)
+        tolog("Switch from current dir %s to job %s workdir %s" % (current_dir, job.jobId, job.workdir))
+
+        real_stagein = False
+        for lfn in job.inFiles:
+            if not (lfn in self.__avail_files):
+                real_stagein = True
+        if not real_stagein:
+            tolog("All files for job %s have copies locally, will try to copy locally" % job.jobId)
+            for lfn in job.inFiles:
+                try:
+                    copy_src = self.__avail_files[lfn]
+                    copy_dest = os.path.join(job.workdir, lfn)
+                    tolog("Copy %s to %s" % (copy_src, copy_dest))
+                    shutil.copyfile(copy_src, copy_dest)
+                except:
+                    tolog("Failed to copy file: %s" % traceback.format_exc())
+                    real_stagein = True
+                    break
+        if not real_stagein:
+            tolog("All files for job %s copied locally" % job.jobId)
+            tolog("Switch back from job %s workdir %s to current dir %s" % (job.jobId, job.workdir, current_dir))
+            os.chdir(current_dir)
+            return job, job.inFiles, None, None
+
+
+        tolog("Preparing for get command [stageIn_new]")
+
+        infiles = [e.lfn for e in job.inData]
+
+        tolog("Input file(s): (%s in total)" % len(infiles))
+        for ind, lfn in enumerate(infiles, 1):
+            tolog("%s. %s" % (ind, lfn))
+
+        if not infiles:
+            tolog("No input files for this job .. skip stage-in")
+            return job, infiles, None, False
+
+        t0 = os.times()
+
+        job.result[2], job.pilotErrorDiag, _dummy, FAX_dictionary = mover.get_data_new(job, jobSite, stageinTries=self.__stageinretry, proxycheck=False, workDir=job.workdir, pfc_name=pfc_name)
+
+        t1 = os.times()
+
+        job.timeStageIn = int(round(t1[4] - t0[4]))
+
+        usedFAXandDirectIO = FAX_dictionary.get('usedFAXandDirectIO', False)
+
+        statusPFCTurl = None
+
+        return job, infiles, statusPFCTurl, usedFAXandDirectIO
+
+    @mover.use_newmover(stageInOneJob_new)
     def stageInOneJob(self, job, jobSite, analysisJob, avail_files={}, pfc_name="PoolFileCatalog.xml"):
         """ Perform the stage-in """
 

--- a/RunJobHpcEvent.py
+++ b/RunJobHpcEvent.py
@@ -1642,6 +1642,14 @@ class RunJobHpcEvent(RunJob):
         os.chdir(current_dir)
         tolog("Finished job %s" % job.jobId)
 
+    def ignore_files(self, dir, files):
+        result = []
+        for f in files:
+            if f.startswith("sqlite"):
+                result.append(f)
+        tolog("Ignore files: %s" % result)
+        return result
+
     def copyLogFilesToJob(self):
         found_dirs = {}
         found_files = {}
@@ -1668,7 +1676,7 @@ class RunJobHpcEvent(RunJob):
                 dest_dir = os.path.join(job.workdir, file)
                 try:
                     if file == 'rank_0' or (file.startswith("rank_") and os.path.exists(dest_dir)):
-                        pUtil.recursive_overwrite(path, dest_dir)
+                        pUtil.recursive_overwrite(path, dest_dir, ignore=self.ignore_files)
                 except:
                     tolog("Failed to copy %s to %s: %s" % (path, dest_dir, traceback.format_exc()))
             for file in found_files:
@@ -1685,7 +1693,7 @@ class RunJobHpcEvent(RunJob):
                        or file.startswith("curl_updateEventRanges_")\
                        or file.startswith("surlDictionary") or file.startswith("jobMetrics-rank") or "event_status.dump" in file:
                         if str(jobId) in file:
-                            pUtil.recursive_overwrite(path, dest_dir)
+                            pUtil.recursive_overwrite(path, dest_dir, ignore=self.ignore_files)
                     else:
                         pUtil.recursive_overwrite(path, dest_dir)
                 except:

--- a/movers/mover.py
+++ b/movers/mover.py
@@ -367,6 +367,7 @@ class JobMover(object):
             # all are eventservice input files, consider remote inputs
             for e in remain_files:
                 e.allowRemoteInputs = True
+                e.allowAllInputRSEs = True
             copytools = [('rucio', {'setup': ''})]
             transferred_files, failed_transfers = self.stagein_real(files=remain_files, activity='es_read', copytools=copytools)
             if failed_transfers:

--- a/movers/mover.py
+++ b/movers/mover.py
@@ -149,14 +149,14 @@ class JobMover(object):
             ddms.setdefault(dat['site'], []).append(dat)
 
         for fdat in files:
-            if fdat.objectstoreId and fdat.objectstoreId > 0:
-                # skip OS ddms, objectstoreId -1 means normal RSE
-                #self.log("fdat.objectstoreId: %s" % fdat.objectstoreId)
+            if fdat.storageId and fdat.storageId > 0:
+                # skip OS ddms, storageId -1 means normal RSE
+                #self.log("fdat.storageId: %s" % fdat.storageId)
                 #fdat.inputddms = [fdat.ddmendpoint]         ### is it used for OS?
                 pass
             else:
-                if fdat.objectstoreId == 0:
-                    fdat.objectstoreId = None
+                if fdat.storageId == 0 or fdat.storageId == -1:
+                    fdat.storageId = None
                 # build and order list of local ddms
                 ddmdat = self.ddmconf.get(fdat.ddmendpoint)
                 if not ddmdat:
@@ -168,7 +168,7 @@ class JobMover(object):
                 fdat.inputddms = self._prepare_input_ddm(ddmdat, localddms)
 
         # consider only normal ddmendpoints
-        xfiles = [e for e in files if e.objectstoreId is None]
+        xfiles = [e for e in files if e.storageId is None]
 
         if not xfiles:
             return files
@@ -331,32 +331,21 @@ class JobMover(object):
         for ddm, dat in self.ddmconf.iteritems():
             if dat.get('type') in ['OS_ES', 'OS_LOGS']:
                 os_ddms.setdefault(int(dat.get('resource', {}).get('bucket_id', -1)), ddm)
+        for ddm, dat in self.ddmconf.iteritems():
+            os_ddms.setdefault(int(dat.get('id', -1)), ddm)
 
         self.log("os_ddms: %s" % os_ddms)
 
         for fspec in files:
             if fspec.prodDBlockToken and fspec.prodDBlockToken.isdigit() and int(fspec.prodDBlockToken) > 0:
-                fspec.objectstoreId = int(fspec.prodDBlockToken)
-                fspec.ddmendpoint = os_ddms.get(fspec.objectstoreId)
+                fspec.storageId = int(fspec.prodDBlockToken)
+                fspec.ddmendpoint = os_ddms.get(fspec.storageId)
                 self.get_objectstore_keys(fspec.ddmendpoint)
                 es_files.append(fspec)
-            elif fspec.prodDBlockToken and fspec.prodDBlockToken.strip() == '-1':
-                # es outputs in normal RSEs (not in objectstore) but not registered in rucio
-                fspec.allowRemoteInputs = True
-                fspec.objectstoreId = -1
-                activity = 'es_events_read'
-                self.log("[stage-in] looking for associated storages with activity: %s" % (activity))
-                pandaqueue = self.si.getQueueName()
-                associate_storages = self.si.resolvePandaAssociatedStorages(pandaqueue).get(pandaqueue, {})
-                esDDMEndpoints = associate_storages.get(activity, [])
-                if esDDMEndpoints:
-                    tolog("[stage-in] found associated storages %s with activity: %s" % (esDDMEndpoints, activity))
-                    fspec.ddmendpoint = esDDMEndpoints[0]
-                es_files.append(fspec)
-            elif fspec.prodDBlockToken and fspec.prodDBlockToken.isdigit() and int(fspec.prodDBlockToken) == 0:
+            elif fspec.prodDBlockToken:
                 # es outputs in normal RSEs (not in objectstore) and registered in rucio
                 fspec.allowRemoteInputs = True
-                fspec.objectstoreId = None  # resolve replicas needs to be called for it
+                fspec.storageId = None  # resolve replicas needs to be called for it
                 es_files.append(fspec)
             else:
                 normal_files.append(fspec)

--- a/movers/mover.py
+++ b/movers/mover.py
@@ -312,12 +312,13 @@ class JobMover(object):
             self.log("Failed to get the keyPair name for S3 objectstore from ddm config")
             self.objectstorekeys[ddmendpoint] = {'status': False}
 
-    def stagein(self):
+    def stagein(self, files=None):
         """
             :return: (transferred_files, failed_transfers)
         """
 
-        files = self.job.inData
+        if files is None:
+            files = self.job.inData
         self.log("To stagein files: %s" % files)
 
         normal_files, es_files = [], []

--- a/movers/mover.py
+++ b/movers/mover.py
@@ -342,7 +342,7 @@ class JobMover(object):
                 fspec.ddmendpoint = os_ddms.get(fspec.storageId)
                 self.get_objectstore_keys(fspec.ddmendpoint)
                 es_files.append(fspec)
-            elif fspec.prodDBlockToken:
+            elif fspec.prodDBlockToken and (fspec.prodDBlockToken.strip() == '-1' or fspec.prodDBlockToken.strip() == '0'):
                 # es outputs in normal RSEs (not in objectstore) and registered in rucio
                 fspec.allowRemoteInputs = True
                 fspec.storageId = None  # resolve replicas needs to be called for it
@@ -365,7 +365,8 @@ class JobMover(object):
                 return transferred_files, failed_transfers
 
             # all are eventservice input files, consider remote inputs
-            [e.allowRemoteInputs = True for e in remain_files]
+            for e in remain_files:
+                e.allowRemoteInputs = True
             copytools = [('rucio', {'setup': ''})]
             transferred_files, failed_transfers = self.stagein_real(files=remain_files, activity='es_read', copytools=copytools)
             if failed_transfers:

--- a/movers/rucio_sitemover.py
+++ b/movers/rucio_sitemover.py
@@ -107,7 +107,7 @@ class rucioSiteMover(BaseSiteMover):
         :return:      destination file details (ddmendpoint, surl, pfn)
         """
 
-        if fspec.objectstoreId and int(fspec.objectstoreId) > 0:
+        if fspec.storageId and int(fspec.storageId) > 0:
             cmd = 'rucio upload --no-register --rse %s --scope %s --pfn %s %s' % (fspec.ddmendpoint,
                                                                                   fspec.scope,
                                                                                   fspec.turl,

--- a/movers/rucio_sitemover.py
+++ b/movers/rucio_sitemover.py
@@ -59,10 +59,15 @@ class rucioSiteMover(BaseSiteMover):
         """
 
         if fspec.replicas:
-            cmd = 'rucio download --dir %s --rse %s %s:%s' % (dirname(dst),
-                                                              fspec.replicas[0][0],
-                                                              fspec.scope,
-                                                              fspec.lfn)
+            if not fspec.allowAllInputRSEs:
+                cmd = 'rucio download --dir %s --rse %s %s:%s' % (dirname(dst),
+                                                                  fspec.replicas[0][0],
+                                                                  fspec.scope,
+                                                                  fspec.lfn)
+            else:
+                cmd = 'rucio download --dir %s %s:%s' % (dirname(dst),
+                                                         fspec.scope,
+                                                         fspec.lfn)
         else:
             cmd = 'rucio download --dir %s --rse %s --pfn %s %s:%s' % (dirname(dst),
                                                                        fspec.ddmendpoint,


### PR DESCRIPTION
1) copy jobMetrics-yoda.json to top working directory for ARC.
2) ignore sqlite200 in ES logs copying(when copying logs from rank_* directory to pilot directory).
3) update to download number of events from corecount to corecount*2
4) update to support new mover in RunJobHpcEvent.py
5) update to use storageId(rse id) instead of objectstoreId, in this case we can use normal grid storages.
6) when normal stagein failed, ES will be able to try to stage in files from remote storages with rucio sitemover.
7) stop eventservice when there are too many continuous stageout failures.