### PR TITLE
Main dev

### DIFF
--- a/Job.py
+++ b/Job.py
@@ -585,6 +585,19 @@ class Job:
                 idat[attrname] = ksources[k][ind] if len(ksources[k]) > ind else None
             if 'lfn' in idat and idat['lfn'].startswith("zip://"):
                 idat['lfn'] = idat['lfn'].replace("zip://", "")
+
+            # prodDBlockToken:
+            #  1) number: storageId or objectstoreId
+            #  2) number/number: storageId( or objectstoreId)/pathConvention
+            #  3) normal storage token
+            if 'prodDBlockToken' in idat and idat['prodDBlockToken'] and idat['prodDBlockToken'].count('/') == 1:
+                storageId, pathConvention = idat['prodDBlockToken'].split('/')
+                if storageId.strip() == '0' or storageId.strip() == '-1' or storageId.isdigit():
+                    idat['prodDBlockToken'] = storageId
+                    idat['pathConvention'] = pathConvention
+                    if len(idat['pathConvention']) ==0:
+                        idat['pathConvention'] = None
+
             idat['allowRemoteInputs'] = self.allowRemoteInputs
             idat['cmtconfig'] = self.cmtconfig
             idat['eventService'] = self.eventService
@@ -1019,7 +1032,7 @@ class FileSpec(object):
                     'cmtconfig' # Needed for Singularity
                     ]
 
-    _os_keys = ['eventRangeId', 'storageId', 'eventService', 'allowAllInputRSEs', 'pandaProxySecretKey', 'jobId', 'osPrivateKey', 'osPublicKey']
+    _os_keys = ['eventRangeId', 'storageId', 'eventService', 'allowAllInputRSEs', 'pandaProxySecretKey', 'jobId', 'osPrivateKey', 'osPublicKey', 'pathConvention']
 
     _local_keys = ['type', 'status', 'replicas', 'surl', 'turl', 'mtime', 'status_code']
 

--- a/Job.py
+++ b/Job.py
@@ -598,6 +598,8 @@ class Job:
                     idat['taskId'] = self.taskID
                     if len(idat['pathConvention']) ==0:
                         idat['pathConvention'] = None
+                    else:
+                        idat['pathConvention'] = int(idat['pathConvention'])
 
             idat['allowRemoteInputs'] = self.allowRemoteInputs
             idat['cmtconfig'] = self.cmtconfig

--- a/Job.py
+++ b/Job.py
@@ -595,6 +595,7 @@ class Job:
                 if storageId.strip() == '0' or storageId.strip() == '-1' or storageId.isdigit():
                     idat['prodDBlockToken'] = storageId
                     idat['pathConvention'] = pathConvention
+                    idat['taskId'] = self.taskID
                     if len(idat['pathConvention']) ==0:
                         idat['pathConvention'] = None
 
@@ -1032,7 +1033,7 @@ class FileSpec(object):
                     'cmtconfig' # Needed for Singularity
                     ]
 
-    _os_keys = ['eventRangeId', 'storageId', 'eventService', 'allowAllInputRSEs', 'pandaProxySecretKey', 'jobId', 'osPrivateKey', 'osPublicKey', 'pathConvention']
+    _os_keys = ['eventRangeId', 'storageId', 'eventService', 'allowAllInputRSEs', 'pandaProxySecretKey', 'jobId', 'osPrivateKey', 'osPublicKey', 'pathConvention', 'taskId']
 
     _local_keys = ['type', 'status', 'replicas', 'surl', 'turl', 'mtime', 'status_code']
 

--- a/RunJobEvent.py
+++ b/RunJobEvent.py
@@ -109,7 +109,7 @@ class RunJobEvent(RunJob):
     # ES zip
     __esToZip = True
     __multipleBuckets = None
-    __numBuckets = 10
+    __numBuckets = 1
     __stageOutDDMEndpoint = None
     __stageOutStorageId = None
 

--- a/RunJobEvent.py
+++ b/RunJobEvent.py
@@ -158,8 +158,8 @@ class RunJobEvent(RunJob):
             return 'all_success'
 
     def setFinalESStatus(self, job):
-        if self.__nStageOutFailures >= 3:
-            job.subStatus = 'pilot_failed'  # 'no_events'
+        if self.__nEventsW < 1 and self.__nStageOutFailures >= 3:
+            job.subStatus = 'pilot_failed'
             job.pilotErrorDiag = "Too many stageout failures"
             job.result[0] = "failed"
             job.result[2] = self.__error.ERR_ESRECOVERABLE

--- a/RunJobEvent.py
+++ b/RunJobEvent.py
@@ -108,6 +108,8 @@ class RunJobEvent(RunJob):
 
     # ES zip
     __esToZip = True
+    __multipleBuckets = None
+    __numBuckets = 10
     __stageOutDDMEndpoint = None
     __stageOutStorageId = None
 
@@ -1275,12 +1277,31 @@ class RunJobEvent(RunJob):
             self.__job.outputZipName = os.path.join(self.__job.workdir, "EventService_premerge_%s" % self.__job.jobId)
             self.__job.outputZipEventRangesName = os.path.join(self.__job.workdir, "EventService_premerge_eventranges_%s.txt" % self.__job.jobId)
             catchalls = readpar('catchall')
+
+            if 'multiple_buckets' in catchalls:
+                self.__multipleBuckets = 1
+            if 'multiple_buckets_with_taskid' in catchalls:
+                self.__multipleBuckets = 2
+            if 'disable_multiple_buckets' in catchalls:
+                self.__multipleBuckets = None
+            if "num_buckets=" in catchalls:
+                for catchall in catchalls.split(","):
+                    if 'num_buckets=' in catchall:
+                        name, value = catchall.split('=')
+                        self.__numBuckets = int(value)
+                        if self.__numBuckets < 1:
+                            tolog("Number of buckets %s is smaller than 1, set it to 1" % (self.__numBuckets))
+                            self.__numBuckets = 1
+                        if self.__numBuckets > 99:
+                            tolog("Number of buckets %s is bigger than 99, set it to 99" % (self.__numBuckets))
+                            self.__numBuckets = 99
+
             if 'es_to_zip' in catchalls:
                 self.__esToZip = True
             if 'not_es_to_zip' in catchalls:
                 self.__esToZip = False
             catchalls = readpar('catchall')
-            if 'zip_time_gap' in catchalls:
+            if 'zip_time_gap=' in catchalls:
                 for catchall in catchalls.split(","):
                     if 'zip_time_gap' in catchall:
                         name, value = catchall.split('=')
@@ -1603,7 +1624,7 @@ class RunJobEvent(RunJob):
 
         return ec, pilotErrorDiag, os_bucket_id
 
-    def stage_out_es(self, job, event_range_id, file_paths):
+    def stage_out_es(self, job, event_range_id, file_paths, pathConvention=None):
         """
         event_range_id: event range id as a string.
         file_paths: List of file paths.
@@ -1686,6 +1707,7 @@ class RunJobEvent(RunJob):
                          'scope': job.scopeOut[0],
                          'eventRangeId': event_range_id,
                          'storageId': self.__stageOutStorageId,
+                         'pathConvention': pathConvention,
                          'ddmendpoint': self.__stageOutDDMEndpoint,
                          'pandaProxySecretKey': job.pandaProxySecretKey,
                          'jobId':job.jobId,
@@ -1731,6 +1753,25 @@ class RunJobEvent(RunJob):
 
         return ec, pilotErrorDiag
 
+    def getPathConvention(self, taskId, jobId):
+        # __multipleBuckets:
+        # 1: final path will be atlaseventservice_<pathConvention>
+        # 2: final path will be atlaseventservice_<taskid>_<pathConvention>
+
+        # __numBuckets is from 1 to 99
+
+        # @returns: 
+        #  if multiple buckets with task id: 100 + int(jobid) % __numBuckets
+        #  if multiple buckets without task id: int(jobid) % __numBuckets
+
+        if self.__multipleBuckets:
+            if self.__multipleBuckets == 1:
+                return int(jobId) % self.__numBuckets
+            if self.__multipleBuckets == 2:
+                return int(jobId) % self.__numBuckets + 100
+
+        return None
+
     def stageOutZipFiles_new(self, output_name=None, output_eventRanges=None, output_eventRange_id=None):
         if not self.__esToZip:
             tolog("ES to zip is not configured")
@@ -1764,8 +1805,10 @@ class RunJobEvent(RunJob):
                     handle.write("%s %s\n" % (eventRange, output_eventRanges[eventRange]))
             return 0, None
 
+        pathConvention = self.getPathConvention(self.__job.taskID, self.__job.jobId)
+
         try:
-            ec, pilotErrorDiag, os_bucket_id = self.stage_out_es(self.__job, output_eventRange_id, [output_name])
+            ec, pilotErrorDiag, os_bucket_id = self.stage_out_es(self.__job, output_eventRange_id, [output_name], pathConvention=pathConvention)
         except Exception, e:
             tolog("!!WARNING!!2222!! Caught exception: %s" % (traceback.format_exc()))
         else:
@@ -1803,8 +1846,11 @@ class RunJobEvent(RunJob):
 
                 for chunkEventRanges in pUtil.chunks(eventRanges, 100):
                     tolog("Update event ranges: %s" % chunkEventRanges)
-                    event_status = [{'eventRanges': chunkEventRanges, 'zipFile': {'lfn': os.path.basename(output_name), 'objstoreID': os_bucket_id}}]
-                    status, output = updateEventRanges(event_status, jobId = self.__job.jobId, url=self.getPanDAServer(), version=1, pandaProxySecretKey = self.__job.pandaProxySecretKey)
+                    if pathConvention:
+                        event_status = [{'eventRanges': chunkEventRanges, 'zipFile': {'lfn': os.path.basename(output_name), 'objstoreID': os_bucket_id, 'pathConvention': pathConvention}}]
+                    else:
+                        event_status = [{'eventRanges': chunkEventRanges, 'zipFile': {'lfn': os.path.basename(output_name), 'objstoreID': os_bucket_id}}]
+                    status, output = updateEventRanges(event_status, url=self.getPanDAServer(), version=1, jobId = self.__job.jobId, pandaProxySecretKey = self.__job.pandaProxySecretKey)
                     tolog("Update Event ranges status: %s, output: %s" % (status, output))
                 self.__nStageOutSuccessAfterFailure += 1
                 if self.__nStageOutSuccessAfterFailure > 10:

--- a/RunJobEvent.py
+++ b/RunJobEvent.py
@@ -1635,8 +1635,9 @@ class RunJobEvent(RunJob):
 
             if osddms:
                 self.__stageOutDDMEndpoint = osddms[0]
-                self.__stageOutStorageId = ddmconf.get(self.__stageOutDDMEndpoint, {}).get('resource', {}).get('bucket_id', -1)
-                # self.__stageOutStorageId = ddmconf.get(self.__stageOutDDMEndpoint, {}).get('id', -1)
+                self.__stageOutStorageId = ddmconf.get(self.__stageOutDDMEndpoint, {}).get('id', -1)
+                if self.__stageOutStorageId == -1:
+                    self.__stageOutStorageId = ddmconf.get(self.__stageOutDDMEndpoint, {}).get('resource', {}).get('bucket_id', -1)
             else:
                 tolog("[stage-out-os] no osddms defined, looking for associated storages with activity: %s" % (activity))
                 associate_storages = self.__siteInfo.resolvePandaAssociatedStorages(pandaqueue).get(pandaqueue, {})

--- a/SiteInformation.py
+++ b/SiteInformation.py
@@ -2101,6 +2101,24 @@ class SiteInformation(object):
 
         return ret
 
+    def resolveItems(self, pandaqueues, itemName):
+        """
+            Resolve DDM storages associated to requested pandaqueues
+            :return: list of accepted ddmendpoints
+        """
+
+        if isinstance(pandaqueues, (str, unicode)):
+            pandaqueues = [pandaqueues]
+
+        r = self.loadSchedConfData(pandaqueues, cache_time=6000) or {} # quick stub: fix me later: schedconf should be loaded only once in any init function from top level, cache_time is used as a workaround here
+        #self.schedconf = r
+
+        ret = {}
+        for pandaqueue in set(pandaqueues):
+            ret[pandaqueue] = r.get(pandaqueue, {}).get(itemName, {})
+
+        return ret
+
 
     # Optional
     def getBenchmarkFileName(self, workdir):

--- a/movers/base.py
+++ b/movers/base.py
@@ -106,7 +106,7 @@ class BaseSiteMover(object):
 
         return surl
 
-    def getSURL(self, se, se_path, scope, lfn, job=None):
+    def getSURL(self, se, se_path, scope, lfn, job=None, pathConvention=None):
         """
             Get final destination SURL of file to be moved
             job instance is passing here for possible JOB specific processing ?? FIX ME LATER

--- a/movers/base.py
+++ b/movers/base.py
@@ -106,7 +106,7 @@ class BaseSiteMover(object):
 
         return surl
 
-    def getSURL(self, se, se_path, scope, lfn, job=None, pathConvention=None):
+    def getSURL(self, se, se_path, scope, lfn, job=None, pathConvention=None, ddmType=None):
         """
             Get final destination SURL of file to be moved
             job instance is passing here for possible JOB specific processing ?? FIX ME LATER

--- a/movers/mover.py
+++ b/movers/mover.py
@@ -1087,11 +1087,12 @@ class JobMover(object):
                     se, se_path = dat.get('se', ''), dat.get('path', '')
 
                     if not fdata.surl:
-                        fdata.surl = sitemover.getSURL(surl_protocols[fdata.ddmendpoint].get('se'), surl_protocols[fdata.ddmendpoint].get('path'), fdata.scope, fdata.lfn, self.job) # job is passing here for possible JOB specific processing
+                        # job is passing here for possible JOB specific processing
+                        fdata.surl = sitemover.getSURL(surl_protocols[fdata.ddmendpoint].get('se'), surl_protocols[fdata.ddmendpoint].get('path'), fdata.scope, fdata.lfn, self.job, pathConvention=fdata.pathConvention)
 
                     updateFileState(fdata.lfn, self.workDir, self.job.jobId, mode="file_state", state="not_transferred", ftype="output")
 
-                    fdata.turl = sitemover.getSURL(se, se_path, fdata.scope, fdata.lfn, self.job) # job is passing here for possible JOB specific processing
+                    fdata.turl = sitemover.getSURL(se, se_path, fdata.scope, fdata.lfn, self.job, pathConvention=fdata.pathConvention) # job is passing here for possible JOB specific processing
 
                     self.log("[stage-out] [%s] resolved SURL=%s to be used for lfn=%s, ddmendpoint=%s" % (activity, fdata.surl, fdata.lfn, fdata.ddmendpoint))
                     self.log("[stage-out] [%s] resolved TURL=%s to be used for lfn=%s, ddmendpoint=%s" % (activity, fdata.turl, fdata.lfn, fdata.ddmendpoint))
@@ -1342,8 +1343,8 @@ class JobMover(object):
                 scope, lfn, pfn = fdata.get('scope', ''), fdata.get('lfn'), fdata.get('pfn')
                 guid = fdata.get('guid', '')
 
-                surl = sitemover.getSURL(surl_prot.get('se'), surl_prot.get('path'), scope, lfn, self.job) # job is passing here for possible JOB specific processing
-                turl = sitemover.getSURL(se, se_path, scope, lfn, self.job) # job is passing here for possible JOB specific processing
+                surl = sitemover.getSURL(surl_prot.get('se'), surl_prot.get('path'), scope, lfn, self.job, pathConvention=fdata.pathConvention) # job is passing here for possible JOB specific processing
+                turl = sitemover.getSURL(se, se_path, scope, lfn, self.job, pathConvention=fdata.pathConvention) # job is passing here for possible JOB specific processing
 
                 self.trace_report.update(scope=scope, dataset=fdata.get('dsname_report'), url=surl)
                 self.trace_report.update(catStart=time.time(), filename=lfn, guid=guid.replace('-', ''))

--- a/movers/mover.py
+++ b/movers/mover.py
@@ -991,7 +991,7 @@ class JobMover(object):
                 d = dconf.get('aprotocols', {})
                 xprot = d.get('SE', [])
                 if not xprot:
-                    surl_schema = ['s3'] if dconf.get('type') in ['OS_LOGS', 'OS_ES'] else ['srm', 'gsiftp']
+                    surl_schema = ['s3'] if dconf.get('type') in ['OS_LOGS', 'OS_ES'] else ['srm', 'gsiftp', 'root', 'http']
                     xprot = [e for e in d.get('a', d.get('r', [])) if e[0] and True in set([e[0].startswith(sc) for sc in surl_schema])]
 
                 surl_prot = [dict(se=e[0], path=e[2]) for e in sorted(xprot, key=lambda x: x[1])]
@@ -1088,11 +1088,18 @@ class JobMover(object):
 
                     if not fdata.surl:
                         # job is passing here for possible JOB specific processing
-                        fdata.surl = sitemover.getSURL(surl_protocols[fdata.ddmendpoint].get('se'), surl_protocols[fdata.ddmendpoint].get('path'), fdata.scope, fdata.lfn, self.job, pathConvention=fdata.pathConvention)
+                        fdata.surl = sitemover.getSURL(surl_protocols[fdata.ddmendpoint].get('se'),
+                                                       surl_protocols[fdata.ddmendpoint].get('path'),
+                                                       fdata.scope,
+                                                       fdata.lfn,
+                                                       self.job,
+                                                       pathConvention=fdata.pathConvention,
+                                                       ddmType=self.ddmconf.get(fdata.ddmendpoint, {}).get('type'))
 
                     updateFileState(fdata.lfn, self.workDir, self.job.jobId, mode="file_state", state="not_transferred", ftype="output")
 
-                    fdata.turl = sitemover.getSURL(se, se_path, fdata.scope, fdata.lfn, self.job, pathConvention=fdata.pathConvention) # job is passing here for possible JOB specific processing
+                    # job is passing here for possible JOB specific processing
+                    fdata.turl = sitemover.getSURL(se, se_path, fdata.scope, fdata.lfn, self.job, pathConvention=fdata.pathConvention, ddmType=self.ddmconf.get(fdata.ddmendpoint, {}).get('type'))
 
                     self.log("[stage-out] [%s] resolved SURL=%s to be used for lfn=%s, ddmendpoint=%s" % (activity, fdata.surl, fdata.lfn, fdata.ddmendpoint))
                     self.log("[stage-out] [%s] resolved TURL=%s to be used for lfn=%s, ddmendpoint=%s" % (activity, fdata.turl, fdata.lfn, fdata.ddmendpoint))
@@ -1343,8 +1350,10 @@ class JobMover(object):
                 scope, lfn, pfn = fdata.get('scope', ''), fdata.get('lfn'), fdata.get('pfn')
                 guid = fdata.get('guid', '')
 
-                surl = sitemover.getSURL(surl_prot.get('se'), surl_prot.get('path'), scope, lfn, self.job, pathConvention=fdata.pathConvention) # job is passing here for possible JOB specific processing
-                turl = sitemover.getSURL(se, se_path, scope, lfn, self.job, pathConvention=fdata.pathConvention) # job is passing here for possible JOB specific processing
+                # job is passing here for possible JOB specific processing
+                surl = sitemover.getSURL(surl_prot.get('se'), surl_prot.get('path'), scope, lfn, self.job, pathConvention=fdata.pathConvention, ddmType=self.ddmconf.get(fdata.ddmendpoint, {}).get('type'))
+                # job is passing here for possible JOB specific processing
+                turl = sitemover.getSURL(se, se_path, scope, lfn, self.job, pathConvention=fdata.pathConvention, ddmType=self.ddmconf.get(fdata.ddmendpoint, {}).get('type'))
 
                 self.trace_report.update(scope=scope, dataset=fdata.get('dsname_report'), url=surl)
                 self.trace_report.update(catStart=time.time(), filename=lfn, guid=guid.replace('-', ''))

--- a/movers/objectstore_sitemover.py
+++ b/movers/objectstore_sitemover.py
@@ -56,7 +56,7 @@ class objectstoreSiteMover(rucioSiteMover):
         Overridden method -- unused
         """
         # tolog("To resolve replica for file (%s) protocol (%s) ddm (%s)" % (fspec, protocol, ddm))
-        if ddm:
+        if ddm and fspec.storageId and fspec.storageId > 0:
             if ddm.get('type') in ['OS_LOGS', 'OS_ES']:
                 if ddm.get('aprotocols'):
                     surl_schema = 's3'

--- a/movers/objectstore_sitemover.py
+++ b/movers/objectstore_sitemover.py
@@ -30,7 +30,7 @@ class objectstoreSiteMover(rucioSiteMover):
         """
         pass
 
-    def getSURL(self, se, se_path, scope, lfn, job=None, pathConvention=None):
+    def getSURL(self, se, se_path, scope, lfn, job=None, pathConvention=None, taskId=None):
         """
             Get final destination SURL of file to be moved
             job instance is passing here for possible JOB specific processing ?? FIX ME LATER
@@ -56,7 +56,8 @@ class objectstoreSiteMover(rucioSiteMover):
 
         if pathConvention >= 100:
             pathConvention = pathConvention - 100
-            taskId = job.taskID
+            if taskId is None:
+                taskId = job.taskID
             se_path = "%s-%s-%s" % (se_path, taskId, pathConvention)
         else:
             se_path = "%s-%s" % (se_path, pathConvention)
@@ -84,7 +85,7 @@ class objectstoreSiteMover(rucioSiteMover):
                     surl_schema = 's3'
                     xprot = [e for e in ddm.get('aprotocols').get('r', []) if e[0] and e[0].startswith(surl_schema)]
                     if xprot:
-                        surl = self.getSURL(xprot[0][0], xprot[0][2], fspec.scope, fspec.lfn)
+                        surl = self.getSURL(xprot[0][0], xprot[0][2], fspec.scope, fspec.lfn, pathConvention=fspec.pathConvention, taskId=fspec.taskId)
 
                         return {'ddmendpoint': fspec.ddmendpoint,
                                 'surl': surl,

--- a/movers/objectstore_sitemover.py
+++ b/movers/objectstore_sitemover.py
@@ -30,7 +30,7 @@ class objectstoreSiteMover(rucioSiteMover):
         """
         pass
 
-    def getSURL(self, se, se_path, scope, lfn, job=None):
+    def getSURL(self, se, se_path, scope, lfn, job=None, pathConvention=None):
         """
             Get final destination SURL of file to be moved
             job instance is passing here for possible JOB specific processing ?? FIX ME LATER
@@ -38,6 +38,28 @@ class objectstoreSiteMover(rucioSiteMover):
 
         ### quick fix: this actually should be reported back from Rucio upload in stageOut()
         ### surl is currently (required?) being reported back to Panda in XML
+
+        if job == None or pathConvention == None:
+            surl = se + os.path.join(se_path, lfn)
+            return surl
+
+        # If pathConvention is not None, it means multiple buckets are used.
+        # If pathConvention is bigger than or equal 100:
+        #     The bucket name is '<atlas-eventservice>-<taskid>-<pathConventionNumber>'
+        #     Real pathConvention is pathConvention - 100
+        # Else:
+        #     The bucket name is '<atlas-eventservice>-<pathConventionNumber>'
+        #     Real pathConvention is pathConvention.
+
+        while se_path.endswith("/"):
+            se_path = se_path[:-1]
+
+        if pathConvention >= 100:
+            pathConvention = pathConvention - 100
+            taskId = job.taskID
+            se_path = "%s-%s-%s" % (se_path, taskId, pathConvention)
+        else:
+            se_path = "%s-%s" % (se_path, pathConvention)
 
         surl = se + os.path.join(se_path, lfn)
         return surl


### PR DESCRIPTION
1) using storageId but fallback to bucket id if storageid is not available
2) only when storageId is set, objectstoresitemover will build replica.
3) implementation to support multiple buckets.
4) fix getSURL in objectstoresitemover to use pathConvention.
5) replace readpar to use new function. because readpar is reading old schedconf which can be different from the schedconfi the new mover is using.