### PR TITLE
Updated protocol name "https" -> "davs" for listing rucio replicas

### DIFF
--- a/movers/mover.py
+++ b/movers/mover.py
@@ -204,7 +204,7 @@ class JobMover(object):
         c = Client()
 
         dids = [dict(scope=e.scope, name=e.lfn) for e in xfiles]
-        schemes = ['srm', 'root', 'https', 'gsiftp']
+        schemes = ['srm', 'root', 'davs', 'gsiftp']
         # Get the replica list
         try:
             replicas = c.list_replicas(dids, schemes=schemes)

--- a/movers/storm_sitemover.py
+++ b/movers/storm_sitemover.py
@@ -54,7 +54,7 @@ class stormSiteMover(BaseSiteMover):
         rc = ReplicaClient()
         http_surl_reps = [r for r in rc.list_replicas(dids=[{'scope': fspec.scope,
                                                              'name': fspec.lfn}],
-                                                      schemes=['https'],
+                                                      schemes=['davs'],
                                                       rse_expression=fspec.ddmendpoint)]
         self.log('http_surl_reps: %s' % http_surl_reps)
 


### PR DESCRIPTION
Rucio no longer provides replica location for HTTPS protocol, because the name
was changed to DAVS. We had at least one site where our jobs failed due to
no access to input files using StoRM site mover (GGUS:129509) and there are
more sites that also fail while use StoRM site mover but luckily they fallback
to to lcgcp site mover.