### PR TITLE
add an option to disable get events before Athena ready

### DIFF
--- a/RunJobEvent.py
+++ b/RunJobEvent.py
@@ -171,6 +171,12 @@ class RunJobEvent(RunJob):
             job.result[0] = "failed"
             job.result[2] = self.__error.ERR_NOEVENTS
             job.jobState = "failed"
+        elif self.__eventRangeID_dictionary and self.__nEventsW < 1:
+            job.subStatus = 'pilot_failed'  # 'no_running_events'
+            job.pilotErrorDiag = "Pilot didn't run any events"
+            job.result[0] = "failed"
+            job.result[2] = self.__error.ERR_NOEVENTS
+            job.jobState = "failed"
         elif self.__esFatalCode:
             job.subStatus = 'pilot_failed'
             job.pilotErrorDiag = "AthenaMP fatal error happened"

--- a/RunJobEvent.py
+++ b/RunJobEvent.py
@@ -3281,7 +3281,7 @@ if __name__ == "__main__":
         except Exception, e:
             pilotErrorDiag = "Failed to process job info: %s" % str(e)
             tolog("!!WARNING!!3000!! %s" % (pilotErrorDiag))
-            job.failJob(0, error.ERR_UNKNOWN, job, pilotErrorDiag=pilotErrorDiag)
+            runJob.failJob(0, error.ERR_UNKNOWN, job, pilotErrorDiag=pilotErrorDiag)
         runJob.setJob(job)
 
         # Should the Event Index be used?
@@ -3668,12 +3668,15 @@ if __name__ == "__main__":
 
         # download event ranges before athenaMP
         # Pilot will download some event ranges from the Event Server
-        message = downloadEventRanges(job.jobId, job.jobsetID, job.taskID, job.pandaProxySecretKey, numRanges=job.coreCount * 2, url=runJob.getPanDAServer())
-        # Create a list of event ranges from the downloaded message
-        first_event_ranges = runJob.extractEventRanges(message)
-        if first_event_ranges is None or first_event_ranges == []:
-            tolog("No more events. will finish this job directly")
-            runJob.failJob(0, error.ERR_NOEVENTS, job, pilotErrorDiag="No events before start AthenaMP", pilot_failed=False)
+        catchalls = runJob.resolveConfigItem('catchall')
+        first_event_ranges = None
+        if not(catchalls and 'disable_get_events_before_ready' in catchalls):
+            message = downloadEventRanges(job.jobId, job.jobsetID, job.taskID, job.pandaProxySecretKey, numRanges=job.coreCount * 2, url=runJob.getPanDAServer())
+            # Create a list of event ranges from the downloaded message
+            first_event_ranges = runJob.extractEventRanges(message)
+            if first_event_ranges is None or first_event_ranges == []:
+                tolog("No more events. will finish this job directly")
+                runJob.failJob(0, error.ERR_NOEVENTS, job, pilotErrorDiag="No events before start AthenaMP")
 
         # Get the current list of eventRangeIDs
         currentEventRangeIDs = runJob.extractEventRangeIDs(first_event_ranges)


### PR DESCRIPTION
For ES, there are two ways to get event ranges:
1) Log time ago, ES got event ranges after AthenaMP was ready. But at that time, for ES with multiple consumers, we got many errors 'No available events' when AthenaMP was ready. So the time to setup AthenaMP was wasted.
2)Get event ranges before starting AthenaMP. It's the way currently used. It avoided the issue at 1). But recently there is another issue. On some unstable sites, frequently there are error 'Failed to setup AthenaMP'. These sites consume a lot of events which increases the retry number of events. So some events were wrongly marked as failed after 10 retries.

This option is to give us the ability to switch whether to get events before AthenaMP is ready.

