### PR TITLE
Sitemovers updates (stage-out)

### DIFF
--- a/movers/base.py
+++ b/movers/base.py
@@ -451,6 +451,8 @@ class BaseSiteMover(object):
         except PilotException, e:
             # do clean up
             if e.code == PilotErrors.ERR_FILEEXIST: ## continue execution with further verification of newer file respect to already exist at storage
+                self.log("INFO: StageOutFile() failed with FILEEXIST error: skipped .. will try to verify if newer produced file is the same as from storage")
+
                 file_exist_error = e
             else:
                 self.remote_cleanup(destination, fspec)

--- a/movers/base.py
+++ b/movers/base.py
@@ -444,12 +444,16 @@ class BaseSiteMover(object):
 
         # do stageOutFile
         self.trace_report.update(relativeStart=time.time(), transferStart=time.time())
+        file_exist_error = None
         try:
             dst_checksum, dst_checksum_type = self.stageOutFile(source, destination, fspec)
-        except PilotException:
+        except PilotException, e:
             # do clean up
-            self.remote_cleanup(destination, fspec)
-            raise
+            if e.code == PilotErrors.ERR_FILEEXIST: ## continue execution with further verification of newer file respect to already exist at storage
+                file_exist_error = e
+            else:
+                self.remote_cleanup(destination, fspec)
+                raise
 
         # verify stageout by checksum
         self.trace_report.update(validateStart=time.time())
@@ -465,6 +469,8 @@ class BaseSiteMover(object):
             # Ignore in the case of lsm mover
             if self.name == 'lsm':
                 self.log("Ignoring lsm error")
+                if file_exist_error: ## no way to verify newer file against already exist at storage: do fail transfer with FILEEXIST error
+                    raise file_exist_error
                 return {'checksum': None, 'checksum_type':None, 'filesize':src_fsize}
             else:
                 self.log("Used %s mover" % (self.name))
@@ -493,6 +499,9 @@ class BaseSiteMover(object):
                             self.log("Remote checksum [%s]: %s" % (dst_checksum_type, dst_checksum))
                             self.log("checksum is_verified = %s" % is_verified)
 
+                if not is_verified and file_exist_error: ## newer file is different respect to one from storage: raise initial FILEEXIST error
+                    raise file_exist_error
+
                 if not is_verified:
                     error = "Remote and local checksums (of type %s) do not match for %s (%s != %s)" % \
                                             (src_checksum_type, os.path.basename(destination), dst_checksum, src_checksum)
@@ -508,8 +517,9 @@ class BaseSiteMover(object):
                 self.trace_report.update(clientState="DONE")
                 return {'checksum': dst_checksum, 'checksum_type':dst_checksum_type, 'filesize':src_fsize}
 
-        except PilotException:
-            self.remote_cleanup(destination, fspec)
+        except PilotException, e:
+            if not e.code == PilotErrors.ERR_FILEEXIST:
+                self.remote_cleanup(destination, fspec)
             raise
         except Exception, e:
             self.log("verify StageOut: caught exception while doing file checksum verification: %s ..  skipped" % e)
@@ -523,6 +533,9 @@ class BaseSiteMover(object):
             self.log("Remote filesize [%s]: %s" % (os.path.dirname(destination), dst_fsize))
             self.log("filesize is_verified = %s" % is_verified)
 
+            if not is_verified and file_exist_error: ## newer file is different respect to one from storage: raise initial FILEEXIST error
+                raise file_exist_error
+
             if not is_verified:
                 error = "Remote and local file sizes do not match for %s (%s != %s)" % (os.path.basename(destination), dst_fsize, src_fsize)
                 self.log(error)
@@ -533,12 +546,15 @@ class BaseSiteMover(object):
             return {'checksum': dst_checksum, 'checksum_type':dst_checksum_type, 'filesize':src_fsize}
 
         except PilotException:
-            self.remote_cleanup(destination, fspec)
+            if not e.code == PilotErrors.ERR_FILEEXIST:
+                self.remote_cleanup(destination, fspec)
             raise
         except Exception, e:
             self.log("verify StageOut: caught exception while doing file size verification: %s .. skipped" % e)
 
-        self.remote_cleanup(destination, fspec)
+        if not file_exist_error:
+            self.remote_cleanup(destination, fspec)
+
         raise PilotException("Neither checksum nor file size could be verified (failing job)", code=PilotErrors.ERR_NOFILEVERIFICATION, state='NOFILEVERIFICATION')
 
 

--- a/movers/base.py
+++ b/movers/base.py
@@ -444,7 +444,8 @@ class BaseSiteMover(object):
 
         # do stageOutFile
         self.trace_report.update(relativeStart=time.time(), transferStart=time.time())
-        file_exist_error = None
+        file_exist_error, dst_checksum, dst_checksum_type = None, None, None
+
         try:
             dst_checksum, dst_checksum_type = self.stageOutFile(source, destination, fspec)
         except PilotException, e:
@@ -552,10 +553,11 @@ class BaseSiteMover(object):
         except Exception, e:
             self.log("verify StageOut: caught exception while doing file size verification: %s .. skipped" % e)
 
-        if not file_exist_error:
+        if file_exist_error:
+            raise file_exist_error
+        else:
             self.remote_cleanup(destination, fspec)
-
-        raise PilotException("Neither checksum nor file size could be verified (failing job)", code=PilotErrors.ERR_NOFILEVERIFICATION, state='NOFILEVERIFICATION')
+            raise PilotException("Neither checksum nor file size could be verified (failing job)", code=PilotErrors.ERR_NOFILEVERIFICATION, state='NOFILEVERIFICATION')
 
 
     def stageOutFile(self, source, destination, fspec):

--- a/movers/mover.py
+++ b/movers/mover.py
@@ -441,7 +441,7 @@ class JobMover(object):
             remain_files = [e for e in normal_files if e.status not in ['remote_io', 'transferred', 'no_transfer']]
             remain_non_es_input_files = [e for e in remain_files if not e.eventService]
 
-            # there are non eventservcie input files, will not continue 
+            # there are non eventservcie input files, will not continue
             if remain_non_es_input_files:
                 return transferred_files, failed_transfers
 
@@ -1183,6 +1183,9 @@ class JobMover(object):
                         except PilotException, e:
                             result = e
                             self.log(traceback.format_exc())
+                            if e.code == PilotErrors.ERR_FILEEXIST: ## skip further attempts
+                                self.log('INFO: Error in copying file (fspec %s/%s) (protocol %s/%s) (attempt %s/%s): File already exist: skip further retries (if any)' % (fnum, nfiles, protnum, nprotocols, _attempt, self.stageoutretry))
+                                break
                         except Exception, e:
                             result = PilotException("stageOut failed with error=%s" % e, code=PilotErrors.ERR_STAGEOUTFAILED, state="STAGEOUT_ATTEMPT_FAILED")
                             self.log(traceback.format_exc())

--- a/processes.py
+++ b/processes.py
@@ -43,7 +43,7 @@ def getProcessCommands(euid, pids):
         pUtil.tolog("Command failed: %s" % (rs))
     else:
         # extract the relevant processes
-        pCommands = rs.split('\n') 
+        pCommands = rs.split('\n')
         first = True
         for pCmd in pCommands:
             if first:
@@ -79,10 +79,7 @@ def dumpStackTrace(pid):
         cmd = "pstack %d" % (pid)
         timeout = 60
         exitcode, output = pUtil.timedCommand(cmd, timeout=timeout)
-        if output == "":
-            pUtil.tolog("(pstack returned empty string)")
-        else:
-            pUtil.tolog(out)
+        pUtil.tolog(output or "(pstack returned empty string)")
     else:
         pUtil.tolog("Skipping pstack dump for zombie process")
 
@@ -158,7 +155,7 @@ def killProcesses(pid, pgrp):
                     _t = 10
                     pUtil.tolog("Sleeping %d s to allow process to exit" % (_t))
                     time.sleep(_t)
-    
+
                     # now do a hardkill just in case some processes haven't gone away
                     try:
                         os.kill(i, signal.SIGKILL)
@@ -187,7 +184,7 @@ def checkProcesses(pid):
 
 def killOrphans():
     """ Find and kill all orphan processes belonging to current pilot user """
-    
+
     if 'BOINC' in pUtil.env['sitename']:
         pUtil.tolog("BOINC job, not looking for orphan processes")
         return


### PR DESCRIPTION
Updates of sitemovers stage-out workflow:

 1. Skip removal of remote file if given file is already exist at storage
 2. Try to continue stageout step of file validation by checksum/filesize if given file is already exist at storage. In case of validation error do fail stageout with FILEEXIST error
 3. Skip further transfer attempts in case of file exist error

Fixed typo bug in `processes.py` (undefined variable)