### PR TITLE
Main dev

### DIFF
--- a/Mover.py
+++ b/Mover.py
@@ -184,7 +184,7 @@ def put_data_new(job, jobSite, stageoutTries, log_transfer=False, special_log_tr
     return 0, "", fields, "", len(transferred_files), 0
 
 # new mover implementation
-def put_data_es(job, jobSite, stageoutTries, files, workDir=None):
+def put_data_es(job, jobSite, stageoutTries, files, workDir=None, activity=None):
     """
         Do jobmover.stageout_outfiles or jobmover.stageout_logfiles (if log_transfer=True)
         or jobmover.stageout_logfiles_os (if special_log_transfer=True)
@@ -211,13 +211,16 @@ def put_data_es(job, jobSite, stageoutTries, files, workDir=None):
     error = None
     storageId = None
     try:
+        if not activity:
+            activity = "es_events"
+
         file = files[0]
         if file.storageId and file.storageId != -1:
             storageId = file.storageId
             copytools = [('objectstore', {'setup': ''})]
         else:
             copytools = None
-        transferred_files, failed_transfers = mover.stageout(activity="es_events", files=files, copytools=copytools)
+        transferred_files, failed_transfers = mover.stageout(activity=activity, files=files, copytools=copytools)
     except PilotException, e:
         error = e
     except Exception, e:

--- a/RunJobEvent.py
+++ b/RunJobEvent.py
@@ -1326,12 +1326,23 @@ class RunJobEvent(RunJob):
                 self.__esToZip = False
                 tolog("Disable tar/zip because job.pandaProxySecretKey is defined")
 
-            catchalls = self.resolveConfigItem('catchall')
-            if 'zip_time_gap=' in catchalls:
-                for catchall in catchalls.split(","):
-                    if 'zip_time_gap' in catchall:
-                        name, value = catchall.split('=')
-                        self.__asyncOutputStager_thread_sleep_time = int(value)
+            pledgedcpu = self.resolveConfigItem('pledgedcpu')
+            if pledgedcpu:
+                try:
+                    if int(pledgedcpu) == -1:
+                        self.__asyncOutputStager_thread_sleep_time = 600
+                    else:
+                        self.__asyncOutputStager_thread_sleep_time = 3600 * 2
+                except:
+                    tolog("Failed to read pledgedcpu: %s" % traceback.format_exc())
+
+            zip_time_gap = self.resolveConfigItem('zip_time_gap')
+            if not (zip_time_gap is None or zip_time_gap == ''):
+                try:
+                    self.__asyncOutputStager_thread_sleep_time = int(value)
+                except:
+                    tolog("Failed to read zip time gap: %s" % traceback.format_exc())
+
             tolog("Sleep time between staging out: %s" % self.__asyncOutputStager_thread_sleep_time)
         except:
             tolog("Failed to init zip cofnig: %s" % traceback.format_exc())

--- a/movers/mover.py
+++ b/movers/mover.py
@@ -397,25 +397,6 @@ class JobMover(object):
             self.log("Will stagin normal files: %s" % [f.lfn for f in normal_files])
             transferred_files, failed_transfers = self.stagein_real(files=normal_files, activity='pr')
 
-        if failed_transfers:
-            self.log("Failed to transfer normal files: %s" % failed_transfers)
-            # if it's eventservice, can try remote stagein
-            remain_files = [e for e in normal_files if e.status not in ['remote_io', 'transferred', 'no_transfer']]
-            remain_non_es_input_files = [e for e in remain_files if not e.eventService]
-
-            # there are non eventservcie input files, will not continue 
-            if remain_non_es_input_files:
-                return transferred_files, failed_transfers
-
-            # all are eventservice input files, consider remote inputs
-            for e in remain_files:
-                e.allowRemoteInputs = True
-                e.allowAllInputRSEs = True
-            copytools = [('rucio', {'setup': ''})]
-            transferred_files, failed_transfers = self.stagein_real(files=remain_files, activity='es_read', copytools=copytools)
-            if failed_transfers:
-                return transferred_files, failed_transfers
-
         if es_files:
             self.log("Will stagin es files: %s" % [f.lfn for f in es_files])
             self.trace_report.update(eventType='get_es')

--- a/movers/mover.py
+++ b/movers/mover.py
@@ -46,7 +46,7 @@ class JobMover(object):
     _stagein_sleeptime_min = 20       # seconds, min allowed sleep time in case of stagein failure
     _stagein_sleeptime_max = 50       # seconds, max allowed sleep time in case of stagein failure
 
-    _stageout_sleeptime_min = 4.9*60  # seconds, min allowed sleep time in case of stageout failure
+    _stageout_sleeptime_min = 1*60  # seconds, min allowed sleep time in case of stageout failure
     _stageout_sleeptime_max = 5*60    # seconds, max allowed sleep time in case of stageout failure
 
 
@@ -75,8 +75,8 @@ class JobMover(object):
     def calc_stagein_sleeptime(self):
         return uniform(self._stagein_sleeptime_min, self._stagein_sleeptime_max)
 
-    def calc_stageout_sleeptime(self):
-        return uniform(self._stageout_sleeptime_min, self._stageout_sleeptime_max)
+    def calc_stageout_sleeptime(self, attempt=1):
+        return uniform(self._stageout_sleeptime_min, min(self._stageout_sleeptime_max, (attempt + 1) * self._stageout_sleeptime_min))
 
     @property
     def stageoutretry(self):
@@ -1091,7 +1091,7 @@ class JobMover(object):
                     # loop over multple stage-out attempts
                     for _attempt in xrange(1, self.stageoutretry + 1):
                         if _attempt > 1: # if not first stage-out attempt, take a nap before next attempt
-                            sleep_time = self.calc_stageout_sleeptime()
+                            sleep_time = self.calc_stageout_sleeptime(_attempt)
                             self.log(" -- Waiting %d seconds before next stage-out attempt for file=%s --" % (sleep_time, fdata.lfn))
                             time.sleep(sleep_time)
 
@@ -1353,7 +1353,7 @@ class JobMover(object):
                 for _attempt in xrange(1, self.stageoutretry + 1):
 
                     if _attempt > 1: # if not first stage-out attempt, take a nap before next attempt
-                        sleep_time = self.calc_stageout_sleeptime()
+                        sleep_time = self.calc_stageout_sleeptime(_attempt)
                         self.log(" -- Waiting %d seconds before next stage-out attempt for file=%s --" % (sleep_time, filename))
                         time.sleep(sleep_time)
 


### PR DESCRIPTION
1) clean 'es_read' activity in pilot: 'es_read' was added to read remotely for cases to run ES when there is a local storage downtime. It's not used.
2) to support failover for es: attach two storages in agis for ES, if the first one failed, it will failover to the second storages. For the first storage, it will use 'es_events' activity if defined, otherwise it will use 'pw' activity. So for opportunistic PQs, we need to define 'es_events', but for normal PQs, we can run ES without defining 'es_events'.
3)update the default zip_time_gap. If pledgedcpu is -1, default zip_time_gap is 600(10 minutes). Otherwise it's 2 hours.
4)based on es_failover, ES can support storages blacklisting: either es_events or es_failover can be blacklisted. 