### PR TITLE
direct access workflow upgrade

### DIFF
--- a/Job.py
+++ b/Job.py
@@ -339,7 +339,7 @@ class Job:
             else:
                 self.usePrefetcher = False
             pUtil.tolog("usePrefetcher = %s" % str(self.usePrefetcher))
-       
+
         # Event number ranges relative to in-file position
         if data.has_key('inFilePosEvtNum'):
             if data.get('inFilePosEvtNum', '').lower() == "true":
@@ -533,7 +533,6 @@ class Job:
         self.putLogToOS = str(data.get('putLogToOS')).lower() == 'true' or self.eventService
 
         # for accessmode testing: self.jobPars += " --accessmode=direct"
-
         self.accessmode = ""
         if self.transferType == 'direct': # enable direct access mode
             self.accessmode = 'direct'
@@ -677,13 +676,20 @@ class Job:
             finfo = FileSpec(**idat)
             ref_dat.append(finfo)
 
+        # Set by default direct access mode enabled for Analy jobs but disabled for Prod jobs
+        # isAnalysisJob function could require the instance being finally constructed,
+        # that's why default value of accessmode is put here at the end
+        if not self.accessmode:
+            self.accessmode = 'direct' if self.isAnalysisJob() else 'copy'
+
+
     def removeZipMapString(self, jobParameters):
         """ Retrieve the zipmap string from the jobParameters """
         # This function is needed to save the zipmap string for later use. The zipmap must be removed
         # from the jobParameters before the payload can be executed, but the zipmap can only be
-        # properly populated until after the payload has finished since the final output file list will 
-        # not be known until then. The pilot extracts the final output file list from the jobReport - 
-        # this also means that zipmaps will only be supported for production jobs since only these produce 
+        # properly populated until after the payload has finished since the final output file list will
+        # not be known until then. The pilot extracts the final output file list from the jobReport -
+        # this also means that zipmaps will only be supported for production jobs since only these produce
         # the jobReport. Zipmaps are of interested for spillover jobs.
 
         # Note that updateQueuedataFromJobParameters() might have messed up the jobParameters by adding
@@ -708,7 +714,7 @@ class Job:
     def populateZipMap(self, outFiles, zipmapString):
         """ Populate the zip_map dictionary """
         # The function returns a populated zip_map dictionary using the previously extracted
-        # zipmapString from the jobParameters. The outFiles list is also needed since wildcards 
+        # zipmapString from the jobParameters. The outFiles list is also needed since wildcards
         # might be present in the ZIP_MAP
 
         zip_map = {} # FORMAT: { <archive name1>:[content_file1, ..], .. }

--- a/movers/base.py
+++ b/movers/base.py
@@ -238,7 +238,7 @@ class BaseSiteMover(object):
                 self.log("[stage-in] surl (srm replica) from Rucio: pfn=%s, ddmendpoint=%s, ddm.se=%s, ddm.se_path=%s" % (surl, ddmendpoint, ddm_se, ddm_path))
 
                 for r in replicas:
-                    if r.startswith(ddm_se): # manually form pfn based on protocol.se
+                    if ddm_se and r.startswith(ddm_se): # manually form pfn based on protocol.se
                         r_filename = r.replace(ddm_se, '', 1).replace(ddm_path, '', 1) # resolve replica filename
                         # quick hack: if hosted replica ddmendpoint and input protocol ddmendpoint mismatched => consider replica ddmendpoint.path
                         r_path = protocol.get('path')

--- a/movers/mover.py
+++ b/movers/mover.py
@@ -270,6 +270,7 @@ class JobMover(object):
         except Exception, e:
             raise PilotException("Failed to get replicas from Rucio: %s" % e, code=PilotErrors.ERR_FAILEDLFCGETREPS)
 
+        replicas = list(replicas)
         self.log("replicas received from Rucio: %s" % replicas)
 
         files_lfn = dict(((e.scope, e.lfn), e) for e in xfiles)

--- a/movers/mover.py
+++ b/movers/mover.py
@@ -315,6 +315,9 @@ class JobMover(object):
                 #self.log('rses=%s' % r['rses'])
                 for ddm, replicas in r['rses'].iteritems():
                     replica = get_preferred_replica(r['rses'][ddm], self.remoteinput_allowed_schemas)
+                    if not replica:
+                        continue
+
                     ddm_se, ddm_path = '', ''
 
                     # remoteinput supported replica (root) replica has been found


### PR DESCRIPTION
Base Sitemovers workflow updates:

  - implemented proper direct_access handling both for ANALY and PROD jobs over LAN and WAN in sitemovers
  - set by default direct access mode enabled for Analy jobs but disabled for Prod jobs (in Job class)
  - isolated remoteinput allowed schemes into `JobMover.remoteinput_allowed_schemas`; for the moment 'root' is only considered as allowed schema.. but can be easily extended with davs, gsiftp, etc..

Note: currently, the `getNewJob()` function in  pilot.py modifies `direct_access_lan` and `direct_access_wan` queuedata settings based on Job parameters (e.g. transferType, is Analy) which is duplicating and confusing and actually should not be handled there but moved instead to  Job constructor `Job.setJobDef` (it should be enough just disable 2lines of  queuedata modification below)

As a side effect resetting `direct_access_lan/wan` settings by `getNewJob` will ignore default direct access settings set in `Job.setJobDef`.

https://github.com/PanDAWMS/pilot/blob/main-dev/pilot.py#L2340
```
ec = env['si'].replaceQueuedataField("direct_access_lan", "False")
ec = env['si'].replaceQueuedataField("direct_access_wan", "False")
```