### PR TITLE
allow overwrite sitemovers queuedata settings from AGIS

### DIFF
--- a/Job.py
+++ b/Job.py
@@ -686,7 +686,7 @@ class Job:
 
         try:
             import ast
-            self.overwriteAGISData = self.parseJobPars(self.jobPars, {'--overwriteAGISdata': ast.literal_eval}).get('--overwriteAGISdata', {})
+            self.overwriteAGISData = self.parseJobPars(self.jobPars, {'--overwriteAGISdata': lambda x: ast.literal_eval(x) if x else {}}).get('--overwriteAGISdata', {})
         except Exception, e:
             pUtil.tolog("INFO: Job.parseJobPars() failed... skipped, error=%s" % e)
 
@@ -710,7 +710,7 @@ class Job:
         except ValueError, e:
             pUtil.tolog("Unparsable job arguments. Shlex exception: " + e.message, label='WARNING')
             return {}
-
+        print 'args=', args
         opts, curopt = {}, None
         for arg in args:
             if arg.startswith('-'):

--- a/movers/mover.py
+++ b/movers/mover.py
@@ -505,7 +505,9 @@ class JobMover(object):
 
         pandaqueue = self.si.getQueueName() # FIX ME LATER
         protocols = self.protocols.setdefault(activity, self.si.resolvePandaProtocols(pandaqueue, activity)[pandaqueue])
-        copytools = self.si.resolvePandaCopytools(pandaqueue, activity, copytools)[pandaqueue]
+
+        overwrite = dict([k,v] for k,v in self.job.overwriteAGISData.iteritems() if k in ['copytools', 'acopytools'])
+        copytools = self.si.resolvePandaCopytools(pandaqueue, activity, copytools, masterdata={pandaqueue:overwrite})[pandaqueue]
 
         self.log("stage-in: pq.aprotocols=%s, pq.copytools=%s" % (protocols, copytools))
 
@@ -1001,7 +1003,8 @@ class JobMover(object):
         if copytools:
             self.log("Mover.stageout() [new implementation] [%s]: default copytools=%s" % (activity, copytools))
 
-        copytools = self.si.resolvePandaCopytools(pandaqueue, activities, copytools)[pandaqueue]
+        overwrite = dict([k,v] for k,v in self.job.overwriteAGISData.iteritems() if k in ['copytools', 'acopytools'])
+        copytools = self.si.resolvePandaCopytools(pandaqueue, activities, copytools, masterdata={pandaqueue:overwrite})[pandaqueue]
 
         self.log("Mover.stageout() [new implementation] started for activity=%s, order of activities=%s, files=%s, protocols=%s, copytools=%s" % (activity, activities, files, protocols, copytools))
 


### PR DESCRIPTION
Updates:
 - implemented base functionality to parse and overwrite data passed via `jobPars` settings
 - introduced `--overwriteAGISdata` arg option to overwrite queuedata coming from AGIS
 - added `copytools` and `acopytools` entries to overwriteAGISdata, update affected stagein/out functions

The format of `overwriteAGISdata` command line option in JobParameters is a string representation of python structures (need to be overwritten)

e.g.
```
jobPars = '
--overwriteAGISdata "{\'allowfax\':False,\'copytools\':{\'rucio\':{\'setup\':\'fakesetup.sh\'}, \'acopytools\':{\'pr\':[\'rucio\']}}"
'
```

to simply overwrite queuedata both for stage-in and stage-out (e.g. by HC jobs) and force use of `Rucio` sitemover following settings can be passed:
```
--overwriteAGISdata "{'copytools':{'rucio':{'setup':''}, 'acopytools':{}}"
```