### PR TITLE
stage-in updates

### DIFF
--- a/Job.py
+++ b/Job.py
@@ -1194,15 +1194,19 @@ class FileSpec(object):
             self.checksum = checksum
 
     def is_directaccess(self, ensure_replica=True):
+        """
+            Check if given file can be used for direct access mode by Job transformation script
+            :param ensure_replica: boolean, if True then check by allowed schemas of file replica turl will be considered as well
+            :return: boolean
+        """
 
-        from SiteMover import SiteMover
-        # is_rootfile = '.root' in self.lfn
-        sm = SiteMover()
-        is_rootfile = sm.isRootFileName(self.lfn)
+        # check by filename pattern
+        filename = self.lfn.lower()
 
+        is_rootfile = True
         exclude_pattern = ['.tar.gz', '.lib.tgz', '.raw.']
         for e in exclude_pattern:
-            if e in self.lfn:
+            if e in filename:
                 is_rootfile = False
                 break
 

--- a/movers/base.py
+++ b/movers/base.py
@@ -155,6 +155,7 @@ class BaseSiteMover(object):
     def check_availablespace(self, maxinputsize, files):
         """
             Verify that enough local space is available to stage in and run the job
+            :raise: PilotException in case of not enough space
         """
 
         if not self.shouldVerifyStageIn():

--- a/movers/mover.py
+++ b/movers/mover.py
@@ -566,6 +566,10 @@ class JobMover(object):
         sitemover_objects = {}
         is_replicas_resolved = False
 
+        if allow_directaccess:
+            # sort files to get candidates for remote_io coming first in order to exclude them from checking of available space for stage-in
+            remain_files = sorted(remain_files, key=lambda x: x.is_directaccess(ensure_replica=False), reverse=True)
+
         for fnum, fdata in enumerate(remain_files, 1):
 
             self.log('INFO: prepare to transfer (stage-in) %s/%s file: lfn=%s' % (fnum, nfiles, fdata.lfn))

--- a/movers/mv_sitemover.py
+++ b/movers/mv_sitemover.py
@@ -23,6 +23,15 @@ class mvSiteMover(BaseSiteMover):
         super(mvSiteMover, self).__init__(*args, **kwargs)
         self.init_dir = os.environ['HOME']
 
+    def check_availablespace(self, maxinputsize, files):
+        """
+            Verify that enough local space is available to stage in and run the job
+            :raise: PilotException in case of not enough space
+            Not applicable for given Mover
+        """
+        pass
+
+
     def createOutputList(self, fspec, dest):
 
         if fspec.turl.startswith('s3://'):
@@ -52,7 +61,7 @@ class mvSiteMover(BaseSiteMover):
     def getSURL(self, se, se_path, scope, lfn, job=None, pathConvention=None, ddmEndpoint=None):
         """
         Override from base because it throws an exception for paths without
-        '/rucio' so we need this to do OS uploads 
+        '/rucio' so we need this to do OS uploads
         """
 
         ddmType = self.ddmconf.get(ddmEndpoint, {}).get('type')
@@ -84,7 +93,7 @@ class mvSiteMover(BaseSiteMover):
                 # the expected behavior actions:
                 # rucio download valid1:EVNT.01416937._000001.pool.root.1
                 # mv valid1/EVNT.01416937._000001.pool.root.1 ./EVNT.09355665._094116.pool.root.1
-                
+
                 self.log('pp: pre-load files for mv_sitemover: download locally stageIn the file: scope=%s file=%s' % (fspec.scope, fspec.lfn))
 
                 cmd = 'rucio download %s:%s' % (fspec.scope, fspec.lfn)
@@ -95,7 +104,7 @@ class mvSiteMover(BaseSiteMover):
                 output = c.communicate()[0]
                 if c.returncode:
                     raise Exception(output)
-                
+
                 fileRucioLocation='%s/%s' % (fspec.scope, fspec.lfn)  # the place where Rucio downloads file
                 self.log('pp: move from %s to %s' % (fileRucioLocation, fileExpectedLocation))
                 try:
@@ -103,7 +112,7 @@ class mvSiteMover(BaseSiteMover):
                 except OSError, e:
                     raise PilotException('stageIn failed when rename the file from rucio location: %s' % str(e))
         # block preload input file END
-        
+
         src = os.path.join(self.init_dir, fspec.lfn)
         self.log('Creating link from %s to %s' % (fspec.lfn, src))
         try:

--- a/movers/storm_sitemover.py
+++ b/movers/storm_sitemover.py
@@ -30,6 +30,14 @@ class stormSiteMover(BaseSiteMover):
         super(stormSiteMover, self).__init__(*args, **kwargs)
         self.log('storm sitemover version: %s' % self.version)
 
+    def check_availablespace(self, maxinputsize, files):
+        """
+            Verify that enough local space is available to stage in and run the job
+            :raise: PilotException in case of not enough space
+            Not applicable for given Mover
+        """
+        pass
+
     def stageIn(self, source, destination, fspec):
         """
         Query HTTP for etag, then symlink to the pilot working directory.


### PR DESCRIPTION
stage-in updates:
  - first process files which can be potentially used for direct access to exclude them from available space checks
 - exclude available space checks during stage-in for mv and storm site movers
 - clean up