### PR TITLE
to kill AthenaMP if it doesn't response in max_wait

### DIFF
--- a/RunJobEvent.py
+++ b/RunJobEvent.py
@@ -4055,6 +4055,7 @@ if __name__ == "__main__":
                     runJob.setAthenaMPIsReady(False)
 
                     # Wait until AthenaMP is ready to receive another event range
+                    w = 0
                     while not runJob.isAthenaMPReady():
                         # calculate cpu time
                         if time_to_calculate_cuptime < time.time() - 2 * 60:
@@ -4076,6 +4077,7 @@ if __name__ == "__main__":
                         if i%10 == 0:
                             tolog("Event range loop iteration #%d" % (i))
                         i += 1
+                        w += 1
                         time.sleep(nap)
 
                         # Is AthenaMP still running?
@@ -4085,7 +4087,14 @@ if __name__ == "__main__":
 
                         if runJob.isAthenaMPReady():
                             tolog("AthenaMP is ready for new event range")
+                            w = 0
                             break
+                        if w * nap > max_wait * 60:
+                            tolog("AthanaMP has been stuck for %s minutes, will kill AthenaMP" % max_wait)
+                            athenaMPProcess.kill()
+                            job.pilotErrorDiag = "AthenaMP has been stuck for %s minutes" % max_wait
+                            job.result[0] = "failed"
+                            job.result[2] = error.ERR_ESATHENAMPDIED
 
                         # Make sure that the utility subprocess is still running
                         if utility_subprocess:

--- a/RunJobHpcEvent.py
+++ b/RunJobHpcEvent.py
@@ -1132,7 +1132,7 @@ class RunJobHpcEvent(RunJob):
             file.close()
         if hpcManager.isLocalProcess():
             self.__hpcStatue = 'closed'
-            self.updateAllJobsState('finished', self.__hpcStatue)
+            self.updateAllJobsState('transferring', self.__hpcStatue)
 
         hpcManager.setPandaJobStateFile(self.__jobStateFile)
         #self.__stageout_threads = defRes['stageout_threads']


### PR DESCRIPTION
We found that in some cases, one es job only produced 5 events in 5 days. So we should kill jobs like this.