### PR TITLE
Updates related to proper error code handling by movers

### DIFF
--- a/PilotErrors.py
+++ b/PilotErrors.py
@@ -375,7 +375,7 @@ class PilotErrors:
 
 class PilotException(Exception):
 
-    def __init__(self, message, code=PilotErrors.ERR_GENERALERROR, state='', *args):
+    def __init__(self, message, code=PilotErrors.ERR_UNKNOWN, state='', *args):
         self.code = code
         self.state = state
         self.message = message

--- a/movers/lcgcp_sitemover.py
+++ b/movers/lcgcp_sitemover.py
@@ -148,7 +148,7 @@ class lcgcpSiteMover(BaseSiteMover):
 
         token = self.ddmconf.get(fspec.ddmendpoint, {}).get('token')
         if not token:
-            raise PilotException("stageOutFile: Failed to resolve token value for ddmendpoint=%s: source=%s, destination=%s, fspec=%s .. unknown ddmendpoint" % (fspec.ddmendpoint, source, destination, fspec))
+            raise PilotException("stageOutFile: Failed to resolve token value for ddmendpoint=%s: source=%s, destination=%s, fspec=%s .. unknown ddmendpoint" % (fspec.ddmendpoint, source, destination, fspec), code=PilotErrors.ERR_STAGEOUTFAILED, state='UNKNOWN_DDMENDPOINT')
         filesize = os.path.getsize(source)
         timeout = self.getTimeOut(filesize)
         cmd = '%s --verbose --vo atlas -b -U srmv2 --connect-timeout=300 --srm-timeout=%s --sendreceive-timeout=%s -S %s %s %s' % (self.copy_command, timeout, timeout, token, source, destination)

--- a/movers/lsm_sitemover.py
+++ b/movers/lsm_sitemover.py
@@ -96,7 +96,7 @@ class lsmSiteMover(BaseSiteMover):
         # resolve token value from fspec.ddmendpoint
         token = self.ddmconf.get(fspec.ddmendpoint, {}).get('token')
         if not token:
-            raise PilotException("stageOutFile: Failed to resolve token value for ddmendpoint=%s: source=%s, destination=%s, fspec=%s .. unknown ddmendpoint" % (fspec.ddmendpoint, source, destination, fspec))
+            raise PilotException("stageOutFile: Failed to resolve token value for ddmendpoint=%s: source=%s, destination=%s, fspec=%s .. unknown ddmendpoint" % (fspec.ddmendpoint, source, destination, fspec), code=PilotErrors.ERR_STAGEOUTFAILED, state='UNKNOWN_DDMENDPOINT')
         filesize = os.path.getsize(source)
 
         checksum = fspec.get_checksum()

--- a/movers/mover.py
+++ b/movers/mover.py
@@ -837,7 +837,8 @@ class JobMover(object):
             if fdata.status == 'error' and not skip_transfer_failure:
                 self.log('stage-in of file (%s/%s) with lfn=%s failed: code=%s .. skip transferring remaining files..' % (fnum, nfiles, fdata.lfn, fdata.status_code))
                 dumpFileStates(self.workDir, self.job.jobId, ftype="input")
-                raise PilotException("STAGEIN FAILED: %s: lfn=%s, error=%s" % (PilotErrors.getErrorStr(fdata.status_code), fdata.lfn, getattr(fdata, 'status_message', '')), code=fdata.status_code, state='STAGEIN_FILE_FAILED')
+                status_code = fdata.status_code if fdata.status_code != PilotErrors.ERR_UNKNOWN else PilotErrors.ERR_STAGEINFAILED
+                raise PilotException("STAGEIN FAILED: %s: lfn=%s, error=%s" % (PilotErrors.getErrorStr(status_code), fdata.lfn, getattr(fdata, 'status_message', '')), code=status_code, state='STAGEIN_FILE_FAILED')
 
             if bad_copytools:
                 raise PilotException("STAGEIN FAILED: bad copytools: no supported copytools", code=PilotErrors.ERR_NOSTORAGE, state='STAGEIN_BAD_COPYTOOLS')
@@ -1269,7 +1270,8 @@ class JobMover(object):
             if fdata.status == 'error' and not skip_transfer_failure:
                 self.log('[stage-out] [%s] failed to transfer file (%s/%s) with lfn=%s: code=%s .. skip transferring of remaining data..' % (activity, fnum, nfiles, fdata.lfn, fdata.status_code))
                 dumpFileStates(self.workDir, self.job.jobId, ftype="output")
-                raise PilotException("STAGEOUT FAILED: %s: lfn=%s, error=%s" % (PilotErrors.getErrorStr(fdata.status_code), fdata.lfn, getattr(fdata, 'status_message', '')), code=fdata.status_code, state='STAGEOUT_FILE_FAILED')
+                status_code = fdata.status_code if fdata.status_code != PilotErrors.ERR_UNKNOWN else PilotErrors.ERR_STAGEOUTFAILED
+                raise PilotException("STAGEOUT FAILED: %s: lfn=%s, error=%s" % (PilotErrors.getErrorStr(status_code), fdata.lfn, getattr(fdata, 'status_message', '')), code=status_code, state='STAGEOUT_FILE_FAILED')
 
             if bad_copytools:
                 raise PilotException("STAGEOUT FAILED: bad copytools: no supported copytools", code=PilotErrors.ERR_NOSTORAGE, state='STAGEOUT_BAD_COPYTOOLS')
@@ -1335,7 +1337,7 @@ class JobMover(object):
         if not ddmendpoints:
             raise PilotException("Failed to put files: Output ddmendpoint list is not set", code=PilotErrors.ERR_NOSTORAGE)
         if not files:
-            raise PilotException("Failed to put files: empty file list to be transferred")
+            raise PilotException("Failed to put files: empty file list to be transferred", code=PilotErrors.ERR_STAGEOUTFAILED)
 
         missing_ddms = set(ddmendpoints) - set(self.ddmconf)
 

--- a/movers/mv_sitemover.py
+++ b/movers/mv_sitemover.py
@@ -6,7 +6,7 @@
 
 from .base import BaseSiteMover
 
-from PilotErrors import PilotException
+from PilotErrors import PilotErrors, PilotException
 
 import os, re, shutil
 
@@ -110,7 +110,7 @@ class mvSiteMover(BaseSiteMover):
                 try:
                     os.rename(fileRucioLocation, fileExpectedLocation)
                 except OSError, e:
-                    raise PilotException('stageIn failed when rename the file from rucio location: %s' % str(e))
+                    raise PilotException('stageIn failed when rename the file from rucio location: %s' % str(e), code=PilotErrors.ERR_STAGEINFAILED)
         # block preload input file END
 
         src = os.path.join(self.init_dir, fspec.lfn)
@@ -118,10 +118,10 @@ class mvSiteMover(BaseSiteMover):
         try:
             os.symlink(src, fspec.lfn)
         except OSError as e:
-            raise PilotException('stageIn failed: %s' % str(e))
+            raise PilotException('stageIn failed: %s' % str(e), code=PilotErrors.ERR_STAGEINFAILED)
 
         if not os.path.exists(fspec.lfn):
-            raise PilotException('stageIn failed: symlink points to non-existent file')
+            raise PilotException('stageIn failed: symlink points to non-existent file', code=PilotErrors.ERR_STAGEINFAILED)
 
         self.log('Symlink successful')
         checksum, checksum_type = fspec.get_checksum()
@@ -151,7 +151,7 @@ class mvSiteMover(BaseSiteMover):
             if fspec.activity != 'pls':
                 shutil.move(src, dest)
         except IOError as e:
-            raise PilotException('stageOut failed: %s' % str(e))
+            raise PilotException('stageOut failed: %s' % str(e), code=PilotErrors.ERR_STAGEOUTFAILED)
 
         self.log('Copy successful')
 

--- a/movers/rucio_sitemover.py
+++ b/movers/rucio_sitemover.py
@@ -7,7 +7,7 @@
 from .base import BaseSiteMover
 
 from pUtil import tolog
-from PilotErrors import PilotException
+from PilotErrors import PilotErrors, PilotException
 
 # from commands import getstatusoutput
 from TimerCommand import getstatusoutput
@@ -91,7 +91,7 @@ class rucioSiteMover(BaseSiteMover):
             try:
                 self.stageInApi(dst, fspec)
             except Exception as error:
-                raise PilotException('stageIn with API faied:  %s' % error)
+                raise PilotException('stageIn with API faied:  %s' % error, code=PilotErrors.ERR_STAGEINFAILED)
 
         # TODO: fix in rucio download to set specific outputfile
         #       https://its.cern.ch/jira/browse/RUCIO-2063
@@ -103,7 +103,7 @@ class rucioSiteMover(BaseSiteMover):
         tolog('stageInOutput: %s' % o)
 
         if s:
-            raise PilotException('stageIn failed -- could not move downloaded file to destination: %s' % o.replace('\n', ''))
+            raise PilotException('stageIn failed -- could not move downloaded file to destination: %s' % o.replace('\n', ''), code=PilotErrors.ERR_STAGEOUTFAILED)
 
         if not fspec.replicas:
             fspec.filesize = os.path.getsize(dst)
@@ -165,7 +165,7 @@ class rucioSiteMover(BaseSiteMover):
         tolog('stageOutOutput: %s' % o)
 
         if s:
-            raise PilotException('stageOut failed -- rucio upload did not succeed: %s' % o.replace('\n', ''))
+            raise PilotException('stageOut failed -- rucio upload did not succeed: %s' % o.replace('\n', ''), code=PilotErrors.ERR_STAGEOUTFAILED)
 
         return {'ddmendpoint': fspec.ddmendpoint,
                 'surl': fspec.surl,


### PR DESCRIPTION
 - changed default error code for PilotException from ERR_GENERALERROR to ERR_UNKNOWN
 - explicitly set error code for some movers while raising PilotException
 - force to set ERR_STAGEINFAILED/ERR_STAGEOUTFAILED error code at the level of base mover workflow if specific sitemover does not report back a proper error code value