### PR TITLE
Sort replicas fix

### DIFF
--- a/movers/base.py
+++ b/movers/base.py
@@ -259,7 +259,7 @@ class BaseSiteMover(object):
         def get_preferred_replica(replicas, allowed_schemas):
             for sval in allowed_schemas:
                 for r in replicas:
-                    if r and r.startswith('%s://' % schema):
+                    if r and r.startswith('%s://' % sval):
                         return r
             return None
 

--- a/movers/base.py
+++ b/movers/base.py
@@ -257,10 +257,10 @@ class BaseSiteMover(object):
                     break
 
         def get_preferred_replica(replicas, allowed_schemas):
-            for sval in allowed_schemas:
-                for r in replicas:
-                    if r and r.startswith('%s://' % sval):
-                        return r
+            for r in replicas:
+                for sval in allowed_schemas:
+                        if r and r.startswith('%s://' % sval):
+                            return r
             return None
 
         if not replica: # resolve replica from Rucio: use exact pfn from Rucio replicas

--- a/movers/base.py
+++ b/movers/base.py
@@ -259,8 +259,8 @@ class BaseSiteMover(object):
         def get_preferred_replica(replicas, allowed_schemas):
             for r in replicas:
                 for sval in allowed_schemas:
-                        if r and r.startswith('%s://' % sval):
-                            return r
+                    if r and r.startswith('%s://' % sval):
+                        return r
             return None
 
         if not replica: # resolve replica from Rucio: use exact pfn from Rucio replicas

--- a/movers/mover.py
+++ b/movers/mover.py
@@ -302,7 +302,7 @@ class JobMover(object):
             # local replicas
             for ddm in fdat.inputddms: ## iterate over local ddms and check if replica is exist here
 
-                #pfns = r.get('rses', {}).get(ddm)  ## use me when Rucio server-size sort fix will be deployed
+                #pfns = r.get('rses', {}).get(ddm)  ## use me when Rucio server-side sort fix will be deployed
                 pfns = ordered_replicas.get(ddm)    ## quick workaround, use mannually sorted data
 
                 if not pfns: # no replica found for given local ddm
@@ -328,7 +328,7 @@ class JobMover(object):
                 self.log("consider first/closest replica, accessmode=%s, remoteinput_allowed_schemas=%s" % (fdat.accessmode, allowed_schemas))
 
                 for ddm, pfns in r['rses'].iteritems():
-                    pfns = ordered_replicas.get(ddm) or [] ## quick workaround, use manually sorted data, REMOVE ME when Rucio server-size sort fix will be deployed
+                    pfns = ordered_replicas.get(ddm) or [] ## quick workaround, use manually sorted data, REMOVE ME when Rucio server-side sort fix will be deployed
 
                     replica = get_preferred_replica(pfns, self.remoteinput_allowed_schemas)
                     if not replica:

--- a/movers/mover.py
+++ b/movers/mover.py
@@ -327,17 +327,17 @@ class JobMover(object):
                 self.log("No local replicas found for lfn=%s or direct access is set but no local direct access files, but allowRemoteInputs is set, looking for remote inputs" % (fdat.lfn))
                 self.log("consider first/closest replica, accessmode=%s, remoteinput_allowed_schemas=%s" % (fdat.accessmode, allowed_schemas))
 
-                for ddm, pnfs in r['rses'].iteritems():
+                for ddm, pfns in r['rses'].iteritems():
                     pfns = ordered_replicas.get(ddm) or [] ## quick workaround, use manually sorted data, REMOVE ME when Rucio server-size sort fix will be deployed
 
-                    replica = get_preferred_replica(pnfs, self.remoteinput_allowed_schemas)
+                    replica = get_preferred_replica(pfns, self.remoteinput_allowed_schemas)
                     if not replica:
                         continue
 
                     ddm_se, ddm_path = '', ''
 
                     # remoteinput supported replica (root) replica has been found
-                    fdat.replicas.append((ddm, pnfs, ddm_se, ddm_path))
+                    fdat.replicas.append((ddm, pfns, ddm_se, ddm_path))
                     # break # ignore other remote replicas/sites
 
             # verify filesize and checksum values


### PR DESCRIPTION
movers stage-in: manually sort replicas according to priority values exposed by Rucio

fixes applied to `mover.py` file can be reverted once Rucio server-side patch will be delivered