### PR TITLE
verify objectstore stagein

### DIFF
--- a/movers/base.py
+++ b/movers/base.py
@@ -345,7 +345,7 @@ class BaseSiteMover(object):
             self.log("verify StageIn: caught exception while getting remote file=%s checksum: %s .. skipped" % (source, e))
 
         try:
-            if dst_checksum and dst_checksum_type: # verify against source
+            if dst_checksum and dst_checksum_type and src_checksum and src_checksum_type: # verify against source(currently src_checksum is empty when merging es files from NorduGrid)
 
                 is_verified = src_checksum and src_checksum_type and dst_checksum == src_checksum and dst_checksum_type == src_checksum_type
 

--- a/movers/objectstore_sitemover.py
+++ b/movers/objectstore_sitemover.py
@@ -7,19 +7,19 @@
 from .rucio_sitemover import rucioSiteMover
 
 from pUtil import tolog
-from PilotErrors import PilotException
+from PilotErrors import PilotException, PilotErrors
 
-from commands import getstatusoutput
 import os
-import hashlib
+import time
+
 
 class objectstoreSiteMover(rucioSiteMover):
     """ SiteMover that uses rucio sitemover for both get and put functionality """
 
     name = 'objectstore'
-    schemes = ['srm', 'gsiftp', 'root', 'https', 's3', 's3+rucio'] # list of supported schemes for transfers
+    schemes = ['srm', 'gsiftp', 'root', 'https', 's3', 's3+rucio']  # list of supported schemes for transfers
 
-    require_replicas = True       ## if objectstoreID is set, mover.resolve_replicas() will skip the file
+    require_replicas = True       # if objectstoreID is set, mover.resolve_replicas() will skip the file
 
     def __init__(self, *args, **kwargs):
         super(objectstoreSiteMover, self).__init__(*args, **kwargs)
@@ -36,8 +36,8 @@ class objectstoreSiteMover(rucioSiteMover):
             job instance is passing here for possible JOB specific processing ?? FIX ME LATER
         """
 
-        ### quick fix: this actually should be reported back from Rucio upload in stageOut()
-        ### surl is currently (required?) being reported back to Panda in XML
+        # quick fix: this actually should be reported back from Rucio upload in stageOut()
+        # surl is currently (required?) being reported back to Panda in XML
 
         tolog("getSURL: pathConvention: %s, taskId: %s, ddmEndpoint: %s" % (pathConvention, taskId, ddmEndpoint))
         if pathConvention and pathConvention >= 1000:
@@ -53,7 +53,7 @@ class objectstoreSiteMover(rucioSiteMover):
         if not (ddmType and ddmType in ['OS_ES']):
             return self.getSURLRucio(se, se_path, scope, lfn)
         else:
-            if pathConvention == None:
+            if pathConvention is None:
                 surl = se + os.path.join(se_path, lfn)
             else:
                 # If pathConvention is not None, it means multiple buckets are used.
@@ -114,3 +114,93 @@ class objectstoreSiteMover(rucioSiteMover):
                         surl = self.getSURL(proto[0], proto[2], fspec.scope, fspec.lfn, pathConvention=fspec.pathConvention, taskId=fspec.taskId, ddmEndpoint=fspec.ddmendpoint)
                         return {'ddmendpoint': fspec.ddmendpoint, 'surl': surl, 'pfn': surl}
         return {}
+
+    def stageIn(self, source, destination, fspec):
+        """
+        Use the rucio download command to stage in the file.
+
+        :param source:  overrides parent signature -- unused
+        :param destination:   overrides parent signature -- unused
+        :param fspec: dictionary containing destination replicas, scope, lfn
+        :return:      destination file details (ddmendpoint, surl, pfn)
+        """
+        stagein_result = super(objectstoreSiteMover, self).stageIn(source, destination, fspec)
+
+        # verify checksum
+        src_checksum, src_checksum_type = fspec.get_checksum()
+
+        self.trace_report.update(validateStart=time.time())
+
+        try:
+            dst_checksum, dst_checksum_type = self.calc_file_checksum(destination)
+        except Exception, e:
+            self.log("verify StageIn: caught exception while getting local file=%s checksum: %s .. skipped" % (destination, e))
+
+        try:
+            if dst_checksum and dst_checksum_type and src_checksum and src_checksum_type:  # verify against source
+
+                is_verified = src_checksum and src_checksum_type and dst_checksum == src_checksum and dst_checksum_type == src_checksum_type
+
+                self.log("Remote checksum [%s]: %s  (%s)" % (src_checksum_type, src_checksum, source))
+                self.log("Local  checksum [%s]: %s  (%s)" % (dst_checksum_type, dst_checksum, destination))
+                self.log("checksum is_verified = %s" % is_verified)
+
+                if type(dst_checksum) is str and type(src_checksum) is str:
+                    if len(src_checksum) != len(dst_checksum):
+                        self.log("Local and remote checksums have different lengths (%s vs %s), will lstrip them" % (dst_checksum, src_checksum))
+                        src_checksum = src_checksum.lstrip('0')
+                        dst_checksum = dst_checksum.lstrip('0')
+
+                        is_verified = src_checksum and src_checksum_type and dst_checksum == src_checksum and dst_checksum_type == src_checksum_type
+
+                        self.log("Remote checksum [%s]: %s  (%s)" % (src_checksum_type, src_checksum, source))
+                        self.log("Local  checksum [%s]: %s  (%s)" % (dst_checksum_type, dst_checksum, destination))
+                        self.log("checksum is_verified = %s" % is_verified)
+
+                if not is_verified:
+                    error = "Remote and local checksums (of type %s) do not match for %s (%s != %s)" % \
+                                            (src_checksum_type, os.path.basename(destination), dst_checksum, src_checksum)
+                    if src_checksum_type == 'adler32':
+                        state = 'AD_MISMATCH'
+                        rcode = PilotErrors.ERR_GETADMISMATCH
+                    else:
+                        state = 'MD5_MISMATCH'
+                        rcode = PilotErrors.ERR_GETMD5MISMATCH
+                    raise PilotException(error, code=rcode, state=state)
+
+                self.log("verifying stagein done. [by checksum] [%s]" % source)
+                self.trace_report.update(clientState="DONE")
+                return stagein_result
+
+        except PilotException:
+            raise
+        except Exception, e:
+            self.log("verify StageIn: caught exception while doing file checksum verification: %s ..  skipped" % e)
+
+        # verify filesize
+        try:
+            src_fsize = fspec.filesize
+            dst_fsize = os.path.getsize(destination)
+
+            if src_fsize:
+                is_verified = src_fsize and src_fsize == dst_fsize
+
+                self.log("Remote filesize [%s]: %s" % (os.path.dirname(destination), src_fsize))
+                self.log("Local  filesize [%s]: %s" % (os.path.dirname(destination), dst_fsize))
+                self.log("filesize is_verified = %s" % is_verified)
+
+                if not is_verified:
+                    error = "Remote and local file sizes do not match for %s (%s != %s)" % (os.path.basename(destination), dst_fsize, src_fsize)
+                    self.log(error)
+                    raise PilotException(error, code=PilotErrors.ERR_GETWRONGSIZE, state='FS_MISMATCH')
+
+                self.log("verifying stagein done. [by filesize] [%s]" % source)
+                self.trace_report.update(clientState="DONE")
+                return stagein_result
+
+        except PilotException:
+            raise
+        except Exception, e:
+            self.log("verify StageIn: caught exception while doing file size verification: %s .. skipped" % e)
+
+        return stagein_result

--- a/movers/rucio_sitemover.py
+++ b/movers/rucio_sitemover.py
@@ -46,7 +46,15 @@ class rucioSiteMover(BaseSiteMover):
         tolog('which gfal2: %s' % o)
         tolog('which gfal-copy: %s' % self.__which('gfal-copy'))
 
-    def stageIn(self, turl, dst, fspec):
+    def shouldVerifyStageIn(self):
+        """
+            Should the get operation perform any file size/checksum verifications?
+            can be customized for specific movers
+        """
+
+        return False
+
+    def stageInFile(self, turl, dst, fspec):
         """
         Use the rucio download command to stage in the file.
 
@@ -90,9 +98,7 @@ class rucioSiteMover(BaseSiteMover):
         if not fspec.replicas and not fspec.filesize:
             fspec.filesize = os.path.getsize(dst)
 
-        return {'ddmendpoint': fspec.replicas[0][0] if fspec.replicas else fspec.ddmendpoint,
-                'surl': None,
-                'pfn': fspec.lfn}
+        return None, None
 
     def stageInApi(self, dst, fspec):
 

--- a/movers/rucio_sitemover.py
+++ b/movers/rucio_sitemover.py
@@ -87,7 +87,7 @@ class rucioSiteMover(BaseSiteMover):
         if s:
             raise PilotException('stageIn failed -- could not move downloaded file to destination: %s' % o.replace('\n', ''), code=PilotErrors.ERR_STAGEOUTFAILED)
 
-        if not fspec.replicas:
+        if not fspec.replicas and not fspec.filesize:
             fspec.filesize = os.path.getsize(dst)
 
         return {'ddmendpoint': fspec.replicas[0][0] if fspec.replicas else fspec.ddmendpoint,


### PR DESCRIPTION
sometimes rucio stagein can be successful but the file is not fully downloaded. In this week, this problem caused many ES merge failures. From objectstore server side, we observed that for the same file with multiple downloading, some of the downloading will return wrong size. We are not sure what happens. So it's good to verify the downloads in pilot.