### PR TITLE
Direct access with WebDAV

### DIFF
--- a/Job.py
+++ b/Job.py
@@ -1294,7 +1294,7 @@ class FileSpec(object):
 
         if ensure_replica:
 
-            allowed_replica_schemas = ['root://', 'dcache://', 'dcap://', 'file://', 'https://']
+            allowed_replica_schemas = ['root://', 'davs://', 'dcache://', 'dcap://', 'file://', 'https://']
 
             if self.turl:
                 if True not in set([self.turl.startswith(e) for e in allowed_replica_schemas]):

--- a/movers/mover.py
+++ b/movers/mover.py
@@ -50,7 +50,7 @@ class JobMover(object):
     _stageout_sleeptime_max = 5*60    # seconds, max allowed sleep time in case of stageout failure
 
     direct_remoteinput_allowed_schemas = ['root']  ## list of allowed schemas to be used for direct acccess mode from REMOTE replicas
-    direct_input_allowed_schemas = ['root', 'dcache', 'dcap', 'file', 'https']  ## list of allowed schemas to be used for direct acccess mode from local replicas
+    direct_input_allowed_schemas = ['root', 'davs', 'dcache', 'dcap', 'file', 'https']  ## list of allowed schemas to be used for direct acccess mode from local replicas
 
     remoteinput_allowed_schemas = ['root', 'gsiftp', 'dcap', 'davs', 'srm'] ## extend me later if need
 


### PR DESCRIPTION
Test jobs running against the Dynafed at CERN attempting to benchmark its performance failed because the pilot does not allow dav for direct access. We would like to proceed with these test, also for benchmarking WebDAV against XRootD in general. For this we would like to allow direct access with davs.

From the ROOT perspective both WebDAV and HTTP are implemented by TDavixFile. Both protocols should be allowed for direct access on LAN.