### PR TITLE
fix bug in corruptedfiles

### DIFF
--- a/RunJob.py
+++ b/RunJob.py
@@ -69,7 +69,7 @@ class RunJob(object):
     __yodaNodes = None
     __yodaQueue = None
 
-    __corruptedFiles = []
+    corruptedFiles = []
 
     # Getter and setter methods
 
@@ -533,9 +533,9 @@ class RunJob(object):
             self.cleanup(job, rf=None)
 
         if job.eventServiceMerge:
-            if self.__corruptedFiles:
-                job.corruptedFiles = ','.join([e['lfn'] for e in self.__corruptedFiles])
-                job.result[2] = self.__corruptedFiles[0]['status_code']
+            if self.corruptedFiles:
+                job.corruptedFiles = ','.join([e['lfn'] for e in self.corruptedFiles])
+                job.result[2] = self.corruptedFiles[0]['status_code']
         else:
             pilotExitCode = PilotErrors.ERR_ESRECOVERABLE
         job.setState(["failed", transExitCode, pilotExitCode])
@@ -663,7 +663,7 @@ class RunJob(object):
         for e in job.inData:
             if e.status == 'error':
                 failed_file = {'lfn': e.lfn, 'status': e.status, 'status_code': e.status_code, 'status_message': e.status_message}
-                self.__corruptedFiles.append(failed_file)
+                self.corruptedFiles.append(failed_file)
 
         job.timeStageIn = int(round(t1[4] - t0[4]))
 
@@ -1954,9 +1954,9 @@ if __name__ == "__main__":
         job = ed.interpretPayload(job, res, getstatusoutput_was_interrupted, current_job_number, runCommandList, runJob.getFailureCode())
         if job.result[1] != 0 or job.result[2] != 0:
             if job.eventServiceMerge:
-                if self.__corruptedFiles:
-                    job.corruptedFiles = ','.join([e['lfn'] for e in self.__corruptedFiles])
-                    job.result[2] = self.__corruptedFiles[0]['status_code']
+                if runJob.corruptedFiles:
+                    job.corruptedFiles = ','.join([e['lfn'] for e in runJob.corruptedFiles])
+                    job.result[2] = runJob.corruptedFiles[0]['status_code']
                 else:
                     job.result[2] = PilotErrors.ERR_ESRECOVERABLE
             runJob.failJob(job.result[1], job.result[2], job, pilotErrorDiag=job.pilotErrorDiag)


### PR DESCRIPTION
In one place: self.corruptedFiles should be runJob.corruptedFiles.
fixed it.
Here are the new test jobs:
https://bigpanda.cern.ch/tasknew/17092639/